### PR TITLE
feat: footerのコピーライトをNekonokoに修正する

### DIFF
--- a/src/components/Templates/Footer/index.tsx
+++ b/src/components/Templates/Footer/index.tsx
@@ -11,7 +11,7 @@ export function Footer() {
       }}
     >
       <Typography variant="body2" color="textSecondary">
-        &copy; {new Date().getFullYear()} Shun Yoshiya. All rights are reserved.
+        &copy; {new Date().getFullYear()} Nekonoko. All rights are reserved.
       </Typography>
     </Box>
   );


### PR DESCRIPTION
## 概要

Footer に表示されているコピーライトの名前を修正する。

## 対応 Issue

Closes #103

## 変更内容

- `src/components/Templates/Footer/index.tsx`: `Shun Yoshiya` → `Nekonoko` に変更

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [ ] テスト通過 (`pnpm test`) ※ロジック変更なし
- [ ] lint / build は CI で確認