### PR TITLE
feat: Atoms コンポーネントを新デザインに刷新する

### DIFF
--- a/src/assets/themes/index.ts
+++ b/src/assets/themes/index.ts
@@ -53,6 +53,7 @@ export const defaultTheme = createTheme({
       default: COLOR_PALETTE.bgBase,
       paper: COLOR_PALETTE.surface2,
     },
+    divider: COLOR_PALETTE.border,
   },
   typography: {
     fontFamily: 'var(--font-noto-sans-jp), "Noto Sans JP", sans-serif',

--- a/src/components/Atoms/Button/index.stories.tsx
+++ b/src/components/Atoms/Button/index.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof Button> = {
     docs: {
       description: {
         component:
-          "ボタン用のAtomコンポーネント。ラベルやアイコン、バリアントをpropsで指定可能。CTA ボタンは color=\"secondary\"（Amber）を使用する。",
+          'ボタン用のAtomコンポーネント。ラベルやアイコン、バリアントをpropsで指定可能。CTA ボタンは color="secondary"（Amber）を使用する。',
       },
     },
   },

--- a/src/components/Atoms/Button/index.stories.tsx
+++ b/src/components/Atoms/Button/index.stories.tsx
@@ -1,7 +1,6 @@
 import { Button } from "./index";
 import type { Meta, StoryObj } from "@storybook/nextjs";
 
-//👇 This default export determines where your story goes in the story list
 const meta: Meta<typeof Button> = {
   component: Button,
   tags: ["autodocs"],
@@ -9,7 +8,7 @@ const meta: Meta<typeof Button> = {
     docs: {
       description: {
         component:
-          "ボタン用のAtomコンポーネント。ラベルやアイコン、バリアントをpropsで指定可能。",
+          "ボタン用のAtomコンポーネント。ラベルやアイコン、バリアントをpropsで指定可能。CTA ボタンは color=\"secondary\"（Amber）を使用する。",
       },
     },
   },
@@ -21,6 +20,14 @@ type Story = StoryObj<typeof Button>;
 export const Standard: Story = {
   args: {
     children: "サンプル",
+  },
+};
+
+export const CTA: Story = {
+  args: {
+    children: "学習を記録する",
+    variant: "contained",
+    color: "secondary",
   },
 };
 

--- a/src/components/Atoms/Card/index.stories.tsx
+++ b/src/components/Atoms/Card/index.stories.tsx
@@ -1,7 +1,6 @@
 import { Card } from "./index";
 import type { Meta, StoryObj } from "@storybook/nextjs";
 
-//👇 This default export determines where your story goes in the story list
 const meta: Meta<typeof Card> = {
   component: Card,
   tags: ["autodocs"],
@@ -9,7 +8,7 @@ const meta: Meta<typeof Card> = {
     docs: {
       description: {
         component:
-          "カード表示用のAtomコンポーネント。タイトルや内容をpropsで指定可能。",
+          "カード表示用のAtomコンポーネント。variant で soft-shadow / bordered を切り替えられる。",
       },
     },
   },
@@ -22,5 +21,21 @@ export const Default: Story = {
   args: {
     children: "サンプル",
     title: "カード",
+  },
+};
+
+export const SoftShadow: Story = {
+  args: {
+    children: "フォームや統計カードに使用する",
+    title: "Soft Shadow",
+    variant: "soft-shadow",
+  },
+};
+
+export const Bordered: Story = {
+  args: {
+    children: "記録一覧・教材リストに使用する",
+    title: "Bordered",
+    variant: "bordered",
   },
 };

--- a/src/components/Atoms/Card/index.tsx
+++ b/src/components/Atoms/Card/index.tsx
@@ -3,14 +3,33 @@ import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
+type CardVariant = "default" | "soft-shadow" | "bordered";
+
 export type Props = {
   children: React.ReactNode;
   title: string;
+  variant?: CardVariant;
 };
 
-export function Card({ children, title }: Props) {
+const variantStyles: Record<CardVariant, object> = {
+  default: {
+    borderRadius: "var(--radius-card)",
+  },
+  "soft-shadow": {
+    borderRadius: "var(--radius-card)",
+    boxShadow: "var(--shadow-card-soft)",
+    border: "none",
+  },
+  bordered: {
+    borderRadius: "var(--radius-card)",
+    boxShadow: "none",
+    border: "1px solid var(--mui-palette-divider)",
+  },
+};
+
+export function Card({ children, title, variant = "default" }: Props) {
   return (
-    <MUICard>
+    <MUICard sx={variantStyles[variant]}>
       <CardContent>
         <Typography
           variant="caption"

--- a/src/components/Atoms/ListMenu/index.tsx
+++ b/src/components/Atoms/ListMenu/index.tsx
@@ -32,16 +32,14 @@ export function ListMenu({
     <List sx={{ display: row ? "flex" : "block", gap: row ? 4 : 0 }}>
       {items.map((item) => (
         <ListItem key={item.label} disablePadding sx={{ width: "auto" }}>
-          <Link href={item.href} passHref legacyBehavior>
-            <ListItemButton component="a" onClick={onClick}>
-              {showIcons && item.icon && (
-                <ListItemIcon>
-                  <Icon icon={item.icon} />
-                </ListItemIcon>
-              )}
-              <ListItemText primary={item.label} />
-            </ListItemButton>
-          </Link>
+          <ListItemButton component={Link} href={item.href} onClick={onClick}>
+            {showIcons && item.icon && (
+              <ListItemIcon>
+                <Icon icon={item.icon} />
+              </ListItemIcon>
+            )}
+            <ListItemText primary={item.label} />
+          </ListItemButton>
         </ListItem>
       ))}
     </List>

--- a/src/components/Atoms/Select/index.stories.tsx
+++ b/src/components/Atoms/Select/index.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Select> = {
     docs: {
       description: {
         component:
-          "セレクトボックス用のAtomコンポーネント。選択肢やラベルをpropsで指定可能。",
+          "セレクトボックス用のAtomコンポーネント。入力背景色 #EAECF5・ラベル常時上部配置をデフォルト適用。",
       },
     },
   },

--- a/src/components/Atoms/Select/index.tsx
+++ b/src/components/Atoms/Select/index.tsx
@@ -46,8 +46,18 @@ function SelectInner<T>(
   const formattedOptions = ["", ...options];
 
   return (
-    <FormControl fullWidth error={error}>
-      <InputLabel id={label}>{label}</InputLabel>
+    <FormControl
+      fullWidth
+      error={error}
+      sx={{
+        "& .MuiInputBase-root": {
+          backgroundColor: "var(--mui-palette-background-paper)",
+        },
+      }}
+    >
+      <InputLabel id={label} shrink>
+        {label}
+      </InputLabel>
       <MUISelect
         labelId={label}
         id={id}
@@ -56,6 +66,7 @@ function SelectInner<T>(
         onChange={handleChange}
         onBlur={onBlur}
         ref={ref}
+        notched
       >
         {/*
          * optionsの中身がstring[]であればそのまま文字列を表示

--- a/src/components/Atoms/TextField/index.stories.tsx
+++ b/src/components/Atoms/TextField/index.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof TextField> = {
     docs: {
       description: {
         component:
-          "テキスト入力用のAtomコンポーネント。propsでラベルやバリデーションを指定可能。",
+          "テキスト入力用のAtomコンポーネント。入力背景色 #EAECF5・ラベル常時上部配置をデフォルト適用。",
       },
     },
   },

--- a/src/components/Atoms/TextField/index.tsx
+++ b/src/components/Atoms/TextField/index.tsx
@@ -39,6 +39,12 @@ function TextFieldInner(
       fullWidth
       onChange={handleChange}
       ref={ref}
+      slotProps={{ inputLabel: { shrink: true } }}
+      sx={{
+        "& .MuiInputBase-root": {
+          backgroundColor: "var(--mui-palette-background-paper)",
+        },
+      }}
       {...rest}
     />
   );


### PR DESCRIPTION
## 概要

Atoms 層のコンポーネントを Issue #108 で確立したデザイントークンに基づいてアップデートする。

## 対応 Issue

Closes #109

## 変更内容

- **MUI テーマ**: `palette.divider` に `#E2E4F0` を追加（Card bordered 用の border カラーを CSS Variables 経由で管理）
- **Card**: `variant` prop（`"default" | "soft-shadow" | "bordered"`）を追加
  - `soft-shadow`: `--shadow-card-soft` + 角丸 `--radius-card(12px)`
  - `bordered`: `--mui-palette-divider` の 1px ボーダー + 角丸 12px
  - Storybook に 3 バリアントのストーリーを追加
- **TextField**: 入力背景色を `--mui-palette-background-paper(#EAECF5)` に設定、`slotProps.inputLabel.shrink` でラベルを常時上部配置（MUI v9 slots API 対応）
- **Select**: TextField と同様の背景色・`InputLabel shrink` を適用
- **Button**: Storybook に `CTA`（`color="secondary"` = Amber）ストーリーを追加してドキュメント化

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [ ] テスト通過 (`pnpm test`) ※ロジック変更なし
- [ ] lint / build は CI で確認