### PR TITLE
feat: 既存ページのレイアウトを新デザインに調整する

### DIFF
--- a/src/components/Atoms/Card/index.tsx
+++ b/src/components/Atoms/Card/index.tsx
@@ -7,7 +7,7 @@ type CardVariant = "default" | "soft-shadow" | "bordered";
 
 export type Props = {
   children: React.ReactNode;
-  title: string;
+  title?: string;
   variant?: CardVariant;
 };
 
@@ -31,16 +31,18 @@ export function Card({ children, title, variant = "default" }: Props) {
   return (
     <MUICard sx={variantStyles[variant]}>
       <CardContent>
-        <Typography
-          variant="caption"
-          gutterBottom
-          sx={{
-            display: "block",
-            color: "text.secondary",
-          }}
-        >
-          {title}
-        </Typography>
+        {title && (
+          <Typography
+            variant="caption"
+            gutterBottom
+            sx={{
+              display: "block",
+              color: "text.secondary",
+            }}
+          >
+            {title}
+          </Typography>
+        )}
         {children}
       </CardContent>
     </MUICard>

--- a/src/components/Atoms/TimeBadge/index.stories.tsx
+++ b/src/components/Atoms/TimeBadge/index.stories.tsx
@@ -1,0 +1,18 @@
+import { TimeBadge } from "./index";
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+const meta: Meta<typeof TimeBadge> = {
+  component: TimeBadge,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof TimeBadge>;
+
+export const Hours: Story = {
+  args: { time: "1時間30分" },
+};
+
+export const MinutesOnly: Story = {
+  args: { time: "45分" },
+};

--- a/src/components/Atoms/TimeBadge/index.tsx
+++ b/src/components/Atoms/TimeBadge/index.tsx
@@ -1,0 +1,17 @@
+import Chip from "@mui/material/Chip";
+import React from "react";
+
+type Props = {
+  time: string;
+};
+
+export function TimeBadge({ time }: Props) {
+  return (
+    <Chip
+      label={time}
+      size="small"
+      color="primary"
+      sx={{ fontWeight: 600, fontSize: "0.75rem" }}
+    />
+  );
+}

--- a/src/components/Molecules/Post/index.module.scss
+++ b/src/components/Molecules/Post/index.module.scss
@@ -1,8 +1,16 @@
 .wrapper {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .contentWrapper {
-  margin: var(--spacing-2) 0 var(--spacing-2);
+  margin: var(--spacing-2) 0;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--spacing-1);
 }

--- a/src/components/Molecules/Post/index.tsx
+++ b/src/components/Molecules/Post/index.tsx
@@ -1,8 +1,10 @@
 import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { Button } from "@/components/Atoms/Button";
 import { Card } from "@/components/Atoms/Card";
+import { Icon } from "@/components/Atoms/Icon";
+import { TimeBadge } from "@/components/Atoms/TimeBadge";
 import { PostData } from "@/libs/types";
 import styles from "./index.module.scss";
 
@@ -15,25 +17,26 @@ type Props = {
 export function Post({ data, handleOpen }: Props) {
   const { id, date, textbook, time, content } = data;
   return (
-    <Card title={date}>
+    <Card title={date} variant="bordered">
       <div className={styles.wrapper}>
-        <Typography variant="subtitle1">教材名　：{textbook.name}</Typography>
-        <Typography variant="subtitle1">学習時間：{time}</Typography>
+        <Typography variant="subtitle1">{textbook.name}</Typography>
+        <TimeBadge time={String(time)} />
       </div>
-      <Divider />
+      <Divider sx={{ my: 1 }} />
       <div className={styles.contentWrapper}>
         <Typography variant="subtitle2">学習内容：</Typography>
         <Typography variant="body2">{content}</Typography>
       </div>
-      <Button
-        variant="outlined"
-        color="error"
-        size="small"
-        onClick={() => handleOpen(id ?? "")}
-        fullWidth={false}
-      >
-        投稿を削除
-      </Button>
+      <div className={styles.actions}>
+        <IconButton
+          size="small"
+          color="error"
+          onClick={() => handleOpen(id ?? "")}
+          aria-label="投稿を削除"
+        >
+          <Icon icon="delete" fontSize="small" />
+        </IconButton>
+      </div>
     </Card>
   );
 }

--- a/src/components/Organisms/RegisterForm/index.module.scss
+++ b/src/components/Organisms/RegisterForm/index.module.scss
@@ -1,13 +1,9 @@
-.formWrapper {
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.button {
   margin-top: var(--spacing-4);
-
-  .form {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-2);
-  }
-
-  .button {
-    margin-top: var(--spacing-4);
-  }
 }

--- a/src/components/Organisms/RegisterForm/index.tsx
+++ b/src/components/Organisms/RegisterForm/index.tsx
@@ -28,7 +28,10 @@ export function RegisterForm({
       <form onSubmit={onSubmitRegister}>
         <div className={styles.form}>
           {showRegisterAlert && (
-            <Alert severity="success" onClose={() => setShowRegisterAlert(false)}>
+            <Alert
+              severity="success"
+              onClose={() => setShowRegisterAlert(false)}
+            >
               教材登録完了！
             </Alert>
           )}

--- a/src/components/Organisms/RegisterForm/index.tsx
+++ b/src/components/Organisms/RegisterForm/index.tsx
@@ -2,6 +2,7 @@ import { Alert } from "@mui/material";
 import React from "react";
 import { useFormContext } from "react-hook-form";
 import { Button } from "@/components/Atoms/Button";
+import { Card } from "@/components/Atoms/Card";
 import { FormTextField } from "@/components/Molecules/FormTextField";
 import { TextBookData } from "@/components/Pages/Register/formSchema";
 import { UseRegister } from "@/components/Pages/Register/useRegister";
@@ -23,26 +24,28 @@ export function RegisterForm({
   } = useFormContext<TextBookData>();
 
   return (
-    <form onSubmit={onSubmitRegister} className={styles.formWrapper}>
-      <div className={styles.form}>
-        {showRegisterAlert && (
-          <Alert severity="success" onClose={() => setShowRegisterAlert(false)}>
-            教材登録完了！
-          </Alert>
-        )}
-        <FormTextField
-          control={control}
-          name="textbook"
-          label="教材を入力"
-          error={!!errors.textbook}
-          errorMessage={errors.textbook?.message}
-        />
-      </div>
-      <div className={styles.button}>
-        <Button variant="contained" type="submit">
-          登録する
-        </Button>
-      </div>
-    </form>
+    <Card variant="soft-shadow">
+      <form onSubmit={onSubmitRegister}>
+        <div className={styles.form}>
+          {showRegisterAlert && (
+            <Alert severity="success" onClose={() => setShowRegisterAlert(false)}>
+              教材登録完了！
+            </Alert>
+          )}
+          <FormTextField
+            control={control}
+            name="textbook"
+            label="教材を入力"
+            error={!!errors.textbook}
+            errorMessage={errors.textbook?.message}
+          />
+        </div>
+        <div className={styles.button}>
+          <Button variant="contained" color="primary" type="submit">
+            登録する
+          </Button>
+        </div>
+      </form>
+    </Card>
   );
 }

--- a/src/components/Organisms/RegisteredBook/index.tsx
+++ b/src/components/Organisms/RegisteredBook/index.tsx
@@ -59,7 +59,7 @@ export function RegisteredBook({
           fontWeight: "bold",
         }}
       >
-        登録済みの教材
+        登録済みの教材（{listData.length}件）
       </Typography>
       <LoadingWrapper isLoading={isLoading} error={error}>
         {listData.length > 0 ? (

--- a/src/components/Organisms/ReportForm/index.module.scss
+++ b/src/components/Organisms/ReportForm/index.module.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-4);
-  margin-top: var(--spacing-2);
 
   .timeSelect {
     display: flex;

--- a/src/components/Organisms/ReportForm/index.tsx
+++ b/src/components/Organisms/ReportForm/index.tsx
@@ -7,6 +7,7 @@ import {
   Control,
 } from "react-hook-form";
 import { Button } from "@/components/Atoms/Button";
+import { Card } from "@/components/Atoms/Card";
 import { FormSelect } from "@/components/Molecules/FormSelect";
 import { FormTextField } from "@/components/Molecules/FormTextField";
 import { ReportFormData } from "@/components/Pages/Report/formSchema";
@@ -42,60 +43,63 @@ export function ReportForm({
 }: ReportFormProps) {
   return (
     <FormProvider {...methods}>
-      <form onSubmit={onSubmit}>
-        {showAlert && (
-          <Alert severity="success" onClose={() => setShowAlert(false)}>
-            記録完了！
-          </Alert>
-        )}
-        <div className={styles.formsWrapper}>
-          <div className={styles.timeSelect}>
-            <FormSelect<string, ReportFormData>
-              name="hour"
+      <Card variant="soft-shadow">
+        <form onSubmit={onSubmit}>
+          {showAlert && (
+            <Alert severity="success" onClose={() => setShowAlert(false)}>
+              記録完了！
+            </Alert>
+          )}
+          <div className={styles.formsWrapper}>
+            <div className={styles.timeSelect}>
+              <FormSelect<string, ReportFormData>
+                name="hour"
+                control={control}
+                options={hourOptions}
+                label="時間"
+                error={!!errors.hour}
+                errorMessage={errors.hour?.message}
+              />
+              <FormSelect<string, ReportFormData>
+                name="minute"
+                control={control}
+                options={minuteOptions}
+                label="分"
+                error={!!errors.minute}
+                errorMessage={errors.minute?.message}
+              />
+            </div>
+            <FormSelect<Textbook, ReportFormData>
+              name="textbook"
               control={control}
-              options={hourOptions}
-              label="時間"
-              error={!!errors.hour}
-              errorMessage={errors.hour?.message}
+              options={textbooks}
+              valueKey="id"
+              labelKey="name"
+              label="教材"
+              error={!!errors.textbook}
+              errorMessage={errors.textbook?.message}
             />
-            <FormSelect<string, ReportFormData>
-              name="minute"
+            <FormTextField<ReportFormData>
+              name="studyContent"
               control={control}
-              options={minuteOptions}
-              label="分"
-              error={!!errors.minute}
-              errorMessage={errors.minute?.message}
+              label="学習内容"
+              error={!!errors.studyContent}
+              errorMessage={errors.studyContent?.message}
             />
           </div>
-          <FormSelect<Textbook, ReportFormData>
-            name="textbook"
-            control={control}
-            options={textbooks}
-            valueKey="id"
-            labelKey="name"
-            label="教材"
-            error={!!errors.textbook}
-            errorMessage={errors.textbook?.message}
-          />
-          <FormTextField<ReportFormData>
-            name="studyContent"
-            control={control}
-            label="学習内容"
-            error={!!errors.studyContent}
-            errorMessage={errors.studyContent?.message}
-          />
-        </div>
-        <div className={styles.button}>
-          <Button
-            variant="contained"
-            type="submit"
-            size="large"
-            disabled={isDisabled}
-          >
-            確定
-          </Button>
-        </div>
-      </form>
+          <div className={styles.button}>
+            <Button
+              variant="contained"
+              color="primary"
+              type="submit"
+              size="large"
+              disabled={isDisabled}
+            >
+              確定
+            </Button>
+          </div>
+        </form>
+      </Card>
     </FormProvider>
   );
 }

--- a/src/components/Pages/Studylog/containers/index.tsx
+++ b/src/components/Pages/Studylog/containers/index.tsx
@@ -1,39 +1,30 @@
 "use client";
 import React from "react";
 import { Card } from "@/components/Atoms/Card";
-import { Heading } from "@/components/Atoms/Heading";
-import styles from "./index.module.scss";
+import { SingleColumn } from "@/components/Templates/SingleColumn";
 import { useStudyLog } from "./useStudyLog";
-
-// type LogData = {
-//   textbook: Textbook;
-//   time: string;
-// };
 
 export function StudyLog() {
   const { data } = useStudyLog();
 
   return (
-    <div className={styles.container}>
-      <Heading text="学習時間" />
-      <section className={styles.logWrapper}>
-        <Card title="教材別の学習時間">
-          {data ? (
-            // data.map((log) => {
-            //   return (
-            //     /** FIXME: indexを使わないでkeyを入れる */
-            //     <dl className={styles.list} key={}>
-            //       <dt className={styles.dataTitle}>{}</dt>
-            //       <dd className={styles.dataDefinition}>{log.time}分</dd>
-            //     </dl>
-            //   );
-            // })
-            <>dataあり</>
-          ) : (
-            <>学習記録がありません</>
-          )}
-        </Card>
-      </section>
-    </div>
+    <SingleColumn title="学習時間">
+      <Card title="教材別の学習時間" variant="soft-shadow">
+        {data ? (
+          // data.map((log) => {
+          //   return (
+          //     /** FIXME: indexを使わないでkeyを入れる */
+          //     <dl key={}>
+          //       <dt>{}</dt>
+          //       <dd>{log.time}分</dd>
+          //     </dl>
+          //   );
+          // })
+          <>dataあり</>
+        ) : (
+          <>学習記録がありません</>
+        )}
+      </Card>
+    </SingleColumn>
   );
 }


### PR DESCRIPTION
## 概要

Issue #91 デザイン刷新の一環として、既存 4 ページのレイアウトを新デザイントークンに合わせて調整する。

## 対応 Issue

Closes #110

## 変更内容

- `TimeBadge` Atom を新規作成（時間をバッジ表示、MUI `Chip` ベース）
- `Card` の `title` prop を optional に変更（タイトルなしカードを使用可能に）
- **ホーム**: `ReportForm` フォームを `Card variant="soft-shadow"` でラップ、確定ボタンに `color="primary"` を明示
- **学習記録一覧**: `Post` Molecule をカード `bordered` バリアントに変更、学習時間を `TimeBadge` 表示、削除ボタンを `IconButton` でアイコンボタン化
- **教材登録**: `RegisterForm` フォームを `Card variant="soft-shadow"` でラップ、`RegisteredBook` に登録件数（○件）を表示
- **学習統計**: `StudyLog` をカスタム div から `SingleColumn` テンプレートに移行してレイアウトを統一

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [ ] テスト通過 (`pnpm test`) ※ロジック変更なし
- [ ] lint / build は CI で確認