### PR TITLE
feat: ホームに日付・ストリーク・直近の記録を追加する

### DIFF
--- a/src/assets/styles/variable.scss
+++ b/src/assets/styles/variable.scss
@@ -34,7 +34,7 @@
   // カラー・背景色はMUIテーマ(cssVariables)が --mui-palette-* として管理する
 
   //shadow (MUI管理外のカスタムトークン)
-  --shadow-card-soft: 0 2px 16px rgba(67, 97, 238, 0.18);
+  --shadow-card-soft: 0 2px 12px rgba(67, 97, 238, 0.10);
   --shadow-card-hover: 0 8px 32px rgba(67, 97, 238, 0.12);
 
   //border-radius (MUI管理外のカスタムトークン)

--- a/src/assets/themes/index.ts
+++ b/src/assets/themes/index.ts
@@ -51,7 +51,7 @@ export const defaultTheme = createTheme({
     },
     background: {
       default: COLOR_PALETTE.bgBase,
-      paper: COLOR_PALETTE.surface2,
+      paper: "#FFFFFF",
     },
     divider: COLOR_PALETTE.border,
   },

--- a/src/components/Atoms/Card/index.tsx
+++ b/src/components/Atoms/Card/index.tsx
@@ -19,6 +19,7 @@ const variantStyles: Record<CardVariant, object> = {
     borderRadius: "var(--radius-card)",
     boxShadow: "var(--shadow-card-soft)",
     border: "none",
+    backgroundColor: "var(--mui-palette-background-default)",
   },
   bordered: {
     borderRadius: "var(--radius-card)",

--- a/src/components/Atoms/StreakBadge/index.stories.tsx
+++ b/src/components/Atoms/StreakBadge/index.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/nextjs";
 import { StreakBadge } from "./index";
+import type { Meta, StoryObj } from "@storybook/nextjs";
 
 const meta: Meta<typeof StreakBadge> = {
   component: StreakBadge,

--- a/src/components/Atoms/StreakBadge/index.stories.tsx
+++ b/src/components/Atoms/StreakBadge/index.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { StreakBadge } from "./index";
+
+const meta: Meta<typeof StreakBadge> = {
+  component: StreakBadge,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof StreakBadge>;
+
+export const Single: Story = {
+  args: { streak: 1 },
+};
+
+export const Week: Story = {
+  args: { streak: 7 },
+};
+
+export const Long: Story = {
+  args: { streak: 30 },
+};

--- a/src/components/Atoms/StreakBadge/index.tsx
+++ b/src/components/Atoms/StreakBadge/index.tsx
@@ -1,4 +1,5 @@
-import Chip from "@mui/material/Chip";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import React from "react";
 
 type Props = {
@@ -7,11 +8,33 @@ type Props = {
 
 export function StreakBadge({ streak }: Props) {
   return (
-    <Chip
-      label={`🔥 ${streak}日連続`}
-      color="warning"
-      size="small"
-      sx={{ fontWeight: 600, fontSize: "0.75rem" }}
-    />
+    <Box
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
+        backgroundColor: "#FFF8E7",
+        border: "1.5px solid rgba(249, 168, 37, 0.3)",
+        borderRadius: "20px",
+        px: "12px",
+        py: "4px",
+      }}
+    >
+      <Box
+        sx={{
+          width: 7,
+          height: 7,
+          backgroundColor: "#F9A825",
+          borderRadius: "50%",
+          flexShrink: 0,
+        }}
+      />
+      <Typography
+        component="span"
+        sx={{ fontSize: "11px", fontWeight: 600, color: "#C67C0E", lineHeight: 1 }}
+      >
+        {streak}日連続学習中
+      </Typography>
+    </Box>
   );
 }

--- a/src/components/Atoms/StreakBadge/index.tsx
+++ b/src/components/Atoms/StreakBadge/index.tsx
@@ -31,7 +31,12 @@ export function StreakBadge({ streak }: Props) {
       />
       <Typography
         component="span"
-        sx={{ fontSize: "11px", fontWeight: 600, color: "#C67C0E", lineHeight: 1 }}
+        sx={{
+          fontSize: "11px",
+          fontWeight: 600,
+          color: "#C67C0E",
+          lineHeight: 1,
+        }}
       >
         {streak}日連続学習中
       </Typography>

--- a/src/components/Atoms/StreakBadge/index.tsx
+++ b/src/components/Atoms/StreakBadge/index.tsx
@@ -1,0 +1,17 @@
+import Chip from "@mui/material/Chip";
+import React from "react";
+
+type Props = {
+  streak: number;
+};
+
+export function StreakBadge({ streak }: Props) {
+  return (
+    <Chip
+      label={`🔥 ${streak}日連続`}
+      color="warning"
+      size="small"
+      sx={{ fontWeight: 600, fontSize: "0.75rem" }}
+    />
+  );
+}

--- a/src/components/Atoms/TimeBadge/index.tsx
+++ b/src/components/Atoms/TimeBadge/index.tsx
@@ -1,4 +1,4 @@
-import Chip from "@mui/material/Chip";
+import Box from "@mui/material/Box";
 import React from "react";
 
 type Props = {
@@ -7,11 +7,23 @@ type Props = {
 
 export function TimeBadge({ time }: Props) {
   return (
-    <Chip
-      label={time}
-      size="small"
-      color="primary"
-      sx={{ fontWeight: 600, fontSize: "0.75rem" }}
-    />
+    <Box
+      component="span"
+      sx={{
+        display: "inline-block",
+        backgroundColor: "#EEF1FF",
+        color: "#4361EE",
+        fontSize: "12px",
+        fontWeight: 700,
+        px: "10px",
+        py: "4px",
+        borderRadius: "12px",
+        flexShrink: 0,
+        whiteSpace: "nowrap",
+        lineHeight: "normal",
+      }}
+    >
+      {time}
+    </Box>
   );
 }

--- a/src/components/Molecules/Post/index.tsx
+++ b/src/components/Molecules/Post/index.tsx
@@ -1,5 +1,5 @@
+import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
-import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { Card } from "@/components/Atoms/Card";
@@ -19,23 +19,35 @@ export function Post({ data, handleOpen }: Props) {
   return (
     <Card title={date} variant="bordered">
       <div className={styles.wrapper}>
-        <Typography variant="subtitle1">{textbook.name}</Typography>
+        <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+          {textbook.name}
+        </Typography>
         <TimeBadge time={String(time)} />
       </div>
       <Divider sx={{ my: 1 }} />
       <div className={styles.contentWrapper}>
-        <Typography variant="subtitle2">学習内容：</Typography>
-        <Typography variant="body2">{content}</Typography>
+        <Typography variant="body2" color="text.secondary">
+          {content}
+        </Typography>
       </div>
       <div className={styles.actions}>
-        <IconButton
+        <Button
           size="small"
-          color="error"
           onClick={() => handleOpen(id ?? "")}
-          aria-label="投稿を削除"
+          startIcon={<Icon icon="delete" fontSize="small" />}
+          sx={{
+            color: "#E53935",
+            border: "1.5px solid #FFE0E0",
+            borderRadius: "8px",
+            fontSize: "12px",
+            fontWeight: 500,
+            py: "5px",
+            px: "12px",
+            "&:hover": { border: "1.5px solid #E53935", backgroundColor: "#FFF0F0" },
+          }}
         >
-          <Icon icon="delete" fontSize="small" />
-        </IconButton>
+          削除
+        </Button>
       </div>
     </Card>
   );

--- a/src/components/Molecules/Post/index.tsx
+++ b/src/components/Molecules/Post/index.tsx
@@ -43,7 +43,10 @@ export function Post({ data, handleOpen }: Props) {
             fontWeight: 500,
             py: "5px",
             px: "12px",
-            "&:hover": { border: "1.5px solid #E53935", backgroundColor: "#FFF0F0" },
+            "&:hover": {
+              border: "1.5px solid #E53935",
+              backgroundColor: "#FFF0F0",
+            },
           }}
         >
           削除

--- a/src/components/Organisms/ReportForm/index.tsx
+++ b/src/components/Organisms/ReportForm/index.tsx
@@ -46,7 +46,11 @@ export function ReportForm({
       <Card variant="soft-shadow">
         <form onSubmit={onSubmit}>
           {showAlert && (
-            <Alert severity="success" onClose={() => setShowAlert(false)}>
+            <Alert
+              severity="success"
+              onClose={() => setShowAlert(false)}
+              sx={{ mb: 2 }}
+            >
               記録完了！
             </Alert>
           )}

--- a/src/components/Pages/Report/index.tsx
+++ b/src/components/Pages/Report/index.tsx
@@ -1,5 +1,14 @@
 "use client";
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import MuiLink from "@mui/material/Link";
+import Typography from "@mui/material/Typography";
+import NextLink from "next/link";
 import React from "react";
+import { Card } from "@/components/Atoms/Card";
+import { StreakBadge } from "@/components/Atoms/StreakBadge";
 import { ReportForm } from "@/components/Organisms/ReportForm";
 import { SingleColumn } from "@/components/Templates/SingleColumn";
 import { useReport } from "./useReport";
@@ -16,10 +25,26 @@ export function Report() {
     showAlert,
     setShowAlert,
     isDisabled,
+    todayLabel,
+    streak,
+    recentPosts,
   } = useReport();
 
   return (
     <SingleColumn title="学習記録">
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          mb: 2,
+        }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          {todayLabel}
+        </Typography>
+        {streak > 0 && <StreakBadge streak={streak} />}
+      </Box>
       <ReportForm
         methods={methods}
         control={control}
@@ -32,6 +57,37 @@ export function Report() {
         setShowAlert={setShowAlert}
         isDisabled={isDisabled}
       />
+      {recentPosts.length > 0 && (
+        <Box sx={{ mt: 3 }}>
+          <Card title="直近の記録" variant="soft-shadow">
+            <List dense disablePadding>
+              {recentPosts.map((post, index) => (
+                <React.Fragment key={post.id}>
+                  {index > 0 && <Divider component="li" />}
+                  <ListItem disablePadding sx={{ py: 0.5 }}>
+                    <Box>
+                      <Typography variant="body2">{post.textbook.name}</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {post.date.slice(0, 10)} · {post.time}
+                      </Typography>
+                    </Box>
+                  </ListItem>
+                </React.Fragment>
+              ))}
+            </List>
+            <Box sx={{ textAlign: "right", mt: 1 }}>
+              <MuiLink
+                component={NextLink}
+                href="/posts"
+                underline="hover"
+                variant="caption"
+              >
+                すべて見る →
+              </MuiLink>
+            </Box>
+          </Card>
+        </Box>
+      )}
     </SingleColumn>
   );
 }

--- a/src/components/Pages/Report/index.tsx
+++ b/src/components/Pages/Report/index.tsx
@@ -1,13 +1,10 @@
 "use client";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
-import MuiLink from "@mui/material/Link";
-import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
 import NextLink from "next/link";
 import React from "react";
-import { Card } from "@/components/Atoms/Card";
 import { StreakBadge } from "@/components/Atoms/StreakBadge";
 import { ReportForm } from "@/components/Organisms/ReportForm";
 import { SingleColumn } from "@/components/Templates/SingleColumn";
@@ -32,16 +29,15 @@ export function Report() {
 
   return (
     <SingleColumn title="学習記録">
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          mb: 2,
-        }}
-      >
-        <Typography variant="body2" color="text.secondary">
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
           {todayLabel}
+        </Typography>
+        <Typography
+          component="h1"
+          sx={{ fontSize: "20px", fontWeight: 700, color: "text.primary", mb: 1.25 }}
+        >
+          今日も学習しよう！
         </Typography>
         {streak > 0 && <StreakBadge streak={streak} />}
       </Box>
@@ -59,35 +55,69 @@ export function Report() {
       />
       {recentPosts.length > 0 && (
         <Box sx={{ mt: 3 }}>
-          <Card title="直近の記録" variant="soft-shadow">
-            <List dense disablePadding>
-              {recentPosts.map((post, index) => (
-                <React.Fragment key={post.id}>
-                  {index > 0 && <Divider component="li" />}
-                  <ListItem disablePadding sx={{ py: 0.5 }}>
-                    <Box>
-                      <Typography variant="body2">
-                        {post.textbook.name}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        {post.date.slice(0, 10)} · {post.time}
-                      </Typography>
-                    </Box>
-                  </ListItem>
-                </React.Fragment>
-              ))}
-            </List>
-            <Box sx={{ textAlign: "right", mt: 1 }}>
-              <MuiLink
-                component={NextLink}
-                href="/posts"
-                underline="hover"
-                variant="caption"
-              >
-                すべて見る →
-              </MuiLink>
-            </Box>
-          </Card>
+          <Typography
+            sx={{
+              fontSize: "11px",
+              fontWeight: 700,
+              color: "text.secondary",
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              mb: 1.25,
+            }}
+          >
+            最近の記録
+          </Typography>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+            {recentPosts.map((post, index) => (
+              <React.Fragment key={post.id}>
+                {index > 0 && <Divider />}
+                <Box
+                  sx={{
+                    backgroundColor: "#F0F1F8",
+                    borderRadius: "10px",
+                    p: "12px",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      mb: 0.5,
+                    }}
+                  >
+                    <Typography sx={{ fontSize: "12px", fontWeight: 600, color: "text.primary" }}>
+                      {post.textbook.name}
+                    </Typography>
+                    <Typography sx={{ fontSize: "11px", fontWeight: 600, color: "#4361EE" }}>
+                      {post.time}
+                    </Typography>
+                  </Box>
+                  <Typography sx={{ fontSize: "11px", color: "text.secondary" }}>
+                    {post.content}
+                  </Typography>
+                </Box>
+              </React.Fragment>
+            ))}
+          </Box>
+          <Button
+            component={NextLink}
+            href="/posts"
+            variant="outlined"
+            fullWidth
+            sx={{
+              mt: 1.5,
+              borderColor: "#C5CEFF",
+              color: "#4361EE",
+              borderRadius: "10px",
+              fontSize: "13px",
+              fontWeight: 600,
+              py: "9px",
+              "&:hover": { borderColor: "#4361EE", backgroundColor: "#EEF1FF" },
+            }}
+          >
+            記録をすべて見る →
+          </Button>
         </Box>
       )}
     </SingleColumn>

--- a/src/components/Pages/Report/index.tsx
+++ b/src/components/Pages/Report/index.tsx
@@ -1,9 +1,9 @@
 "use client";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
+import MuiLink from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import MuiLink from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
 import NextLink from "next/link";
 import React from "react";
@@ -66,7 +66,9 @@ export function Report() {
                   {index > 0 && <Divider component="li" />}
                   <ListItem disablePadding sx={{ py: 0.5 }}>
                     <Box>
-                      <Typography variant="body2">{post.textbook.name}</Typography>
+                      <Typography variant="body2">
+                        {post.textbook.name}
+                      </Typography>
                       <Typography variant="caption" color="text.secondary">
                         {post.date.slice(0, 10)} · {post.time}
                       </Typography>

--- a/src/components/Pages/Report/index.tsx
+++ b/src/components/Pages/Report/index.tsx
@@ -35,7 +35,12 @@ export function Report() {
         </Typography>
         <Typography
           component="h1"
-          sx={{ fontSize: "20px", fontWeight: 700, color: "text.primary", mb: 1.25 }}
+          sx={{
+            fontSize: "20px",
+            fontWeight: 700,
+            color: "text.primary",
+            mb: 1.25,
+          }}
         >
           今日も学習しよう！
         </Typography>
@@ -108,11 +113,19 @@ export function Report() {
                   >
                     {post.textbook.name}
                   </Typography>
-                  <Typography sx={{ fontSize: "10px", color: "text.disabled", mt: "1px" }}>
+                  <Typography
+                    sx={{ fontSize: "10px", color: "text.disabled", mt: "1px" }}
+                  >
                     {String(post.time)}
                   </Typography>
                 </Box>
-                <Typography sx={{ fontSize: "10px", color: "text.disabled", flexShrink: 0 }}>
+                <Typography
+                  sx={{
+                    fontSize: "10px",
+                    color: "text.disabled",
+                    flexShrink: 0,
+                  }}
+                >
                   {post.relativeDateLabel}
                 </Typography>
               </Box>

--- a/src/components/Pages/Report/index.tsx
+++ b/src/components/Pages/Report/index.tsx
@@ -1,10 +1,10 @@
 "use client";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
 import NextLink from "next/link";
 import React from "react";
+import { Icon } from "@/components/Atoms/Icon";
 import { StreakBadge } from "@/components/Atoms/StreakBadge";
 import { ReportForm } from "@/components/Organisms/ReportForm";
 import { SingleColumn } from "@/components/Templates/SingleColumn";
@@ -57,47 +57,65 @@ export function Report() {
         <Box sx={{ mt: 3 }}>
           <Typography
             sx={{
-              fontSize: "11px",
+              fontSize: "10px",
               fontWeight: 700,
-              color: "text.secondary",
+              color: "text.disabled",
               letterSpacing: "0.1em",
               textTransform: "uppercase",
-              mb: 1.25,
+              mb: 1,
             }}
           >
             最近の記録
           </Typography>
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-            {recentPosts.map((post, index) => (
-              <React.Fragment key={post.id}>
-                {index > 0 && <Divider />}
+          <Box sx={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+            {recentPosts.map((post) => (
+              <Box
+                key={post.id}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "9px",
+                  p: "8px 10px",
+                  backgroundColor: "background.paper",
+                  border: "1px solid #E2E4F0",
+                  borderRadius: "8px",
+                }}
+              >
                 <Box
                   sx={{
-                    backgroundColor: "#F0F1F8",
-                    borderRadius: "10px",
-                    p: "12px",
+                    width: 28,
+                    height: 28,
+                    backgroundColor: "#EEF1FF",
+                    borderRadius: "6px",
+                    flexShrink: 0,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
                   }}
                 >
-                  <Box
+                  <Icon icon="book" fontSize="small" color="primary" />
+                </Box>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography
                     sx={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      mb: 0.5,
+                      fontSize: "12px",
+                      fontWeight: 600,
+                      color: "text.primary",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
                     }}
                   >
-                    <Typography sx={{ fontSize: "12px", fontWeight: 600, color: "text.primary" }}>
-                      {post.textbook.name}
-                    </Typography>
-                    <Typography sx={{ fontSize: "11px", fontWeight: 600, color: "#4361EE" }}>
-                      {post.time}
-                    </Typography>
-                  </Box>
-                  <Typography sx={{ fontSize: "11px", color: "text.secondary" }}>
-                    {post.content}
+                    {post.textbook.name}
+                  </Typography>
+                  <Typography sx={{ fontSize: "10px", color: "text.disabled", mt: "1px" }}>
+                    {String(post.time)}
                   </Typography>
                 </Box>
-              </React.Fragment>
+                <Typography sx={{ fontSize: "10px", color: "text.disabled", flexShrink: 0 }}>
+                  {post.relativeDateLabel}
+                </Typography>
+              </Box>
             ))}
           </Box>
           <Button

--- a/src/components/Pages/Report/useReport.ts
+++ b/src/components/Pages/Report/useReport.ts
@@ -15,7 +15,9 @@ function getRelativeDateLabel(dateStr: string): string {
   if (postDate === today) return "今日";
   if (postDate === yesterday) return "昨日";
   const date = new Date(postDate.replace(/\//g, "-"));
-  const diffDays = Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
+  const diffDays = Math.floor(
+    (Date.now() - date.getTime()) / (1000 * 60 * 60 * 24)
+  );
   return `${diffDays}日前`;
 }
 

--- a/src/components/Pages/Report/useReport.ts
+++ b/src/components/Pages/Report/useReport.ts
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import { format, subDays } from "date-fns";
 import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { usePostData } from "@/libs/hooks/usePostData";
@@ -6,6 +7,17 @@ import { useStreak } from "@/libs/hooks/useStreak";
 import { useTextbookData } from "@/libs/hooks/useTextbookData";
 import { ReportData } from "@/libs/types";
 import { formSchema, ReportFormData } from "./formSchema";
+
+function getRelativeDateLabel(dateStr: string): string {
+  const postDate = dateStr.slice(0, 10);
+  const today = format(new Date(), "yyyy/MM/dd");
+  const yesterday = format(subDays(new Date(), 1), "yyyy/MM/dd");
+  if (postDate === today) return "今日";
+  if (postDate === yesterday) return "昨日";
+  const date = new Date(postDate.replace(/\//g, "-"));
+  const diffDays = Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
+  return `${diffDays}日前`;
+}
 
 export function useReport() {
   const { textbooks } = useTextbookData();
@@ -18,7 +30,14 @@ export function useReport() {
     return `${now.getFullYear()}年${now.getMonth() + 1}月${now.getDate()}日（${DAYS[now.getDay()]}）`;
   }, []);
 
-  const recentPosts = useMemo(() => posts?.slice(0, 3) ?? [], [posts]);
+  const recentPosts = useMemo(
+    () =>
+      posts?.slice(0, 3).map((post) => ({
+        ...post,
+        relativeDateLabel: getRelativeDateLabel(post.date),
+      })) ?? [],
+    [posts]
+  );
 
   const [alertShown, setAlertShown] = useState<boolean>(false);
 

--- a/src/components/Pages/Report/useReport.ts
+++ b/src/components/Pages/Report/useReport.ts
@@ -1,14 +1,24 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { usePostData } from "@/libs/hooks/usePostData";
+import { useStreak } from "@/libs/hooks/useStreak";
 import { useTextbookData } from "@/libs/hooks/useTextbookData";
 import { ReportData } from "@/libs/types";
 import { formSchema, ReportFormData } from "./formSchema";
 
 export function useReport() {
   const { textbooks } = useTextbookData();
-  const { postData } = usePostData();
+  const { postData, posts } = usePostData();
+  const streak = useStreak(posts);
+
+  const todayLabel = useMemo(() => {
+    const DAYS = ["日", "月", "火", "水", "木", "金", "土"];
+    const now = new Date();
+    return `${now.getFullYear()}年${now.getMonth() + 1}月${now.getDate()}日（${DAYS[now.getDay()]}）`;
+  }, []);
+
+  const recentPosts = useMemo(() => posts?.slice(0, 3) ?? [], [posts]);
 
   const [alertShown, setAlertShown] = useState<boolean>(false);
 
@@ -84,6 +94,9 @@ export function useReport() {
     showAlert,
     setShowAlert: setAlertShown,
     isDisabled,
+    todayLabel,
+    streak,
+    recentPosts,
   };
 }
 

--- a/src/components/Templates/Header/index.tsx
+++ b/src/components/Templates/Header/index.tsx
@@ -20,7 +20,10 @@ export function Header() {
 
   return (
     <Box sx={{ flexGrow: 1, width: "100%", position: "fixed", zIndex: "100" }}>
-      <AppBar position="static">
+      <AppBar
+        position="static"
+        sx={{ background: "linear-gradient(135deg, #3A0CA3 0%, #4361EE 100%)" }}
+      >
         <Toolbar className={styles.headerMenu}>
           <Link href={URL_VALUES.REPORT} className={styles.link}>
             <Typography color="inherit" variant="h6">

--- a/src/libs/hooks/usePostData.ts
+++ b/src/libs/hooks/usePostData.ts
@@ -97,15 +97,19 @@ export const usePostData = () => {
   useEffect(() => {
     if (!isAppCheckReady) return;
     const unsubscribe = onSnapshot(fetchQuery, (snapshot) => {
-      const updatedPosts = snapshot.docs.map((doc) => {
-        const date = doc.data().createdAt.toDate() as Date;
-        const formatedDate = format(date, "yyyy/MM/dd HH:mm");
-        return {
-          id: doc.id,
-          date: formatedDate,
-          ...doc.data(),
-        };
-      }) as PostData[];
+      // serverTimestamp() 書き込み直後はサーバー確定前に createdAt が null になる
+      // ため、確定済みのドキュメントのみ処理する
+      const updatedPosts = snapshot.docs
+        .filter((doc) => doc.data().createdAt !== null)
+        .map((doc) => {
+          const date = doc.data().createdAt.toDate() as Date;
+          const formatedDate = format(date, "yyyy/MM/dd HH:mm");
+          return {
+            id: doc.id,
+            date: formatedDate,
+            ...doc.data(),
+          };
+        }) as PostData[];
 
       // SWRのキャッシュを更新(データはSWRが保持しているため、ここで更新する必要がある)
       mutate(apiPath, updatedPosts, false);

--- a/src/libs/hooks/useStreak.ts
+++ b/src/libs/hooks/useStreak.ts
@@ -1,0 +1,36 @@
+import { format, subDays } from "date-fns";
+import { useMemo } from "react";
+import { PostData } from "../types";
+
+function calculateStreak(posts: PostData[] | undefined): number {
+  if (!posts || posts.length === 0) return 0;
+
+  // Extract unique dates (first 10 chars: "yyyy/MM/dd") sorted descending
+  const uniqueDates = [...new Set(posts.map((p) => p.date.slice(0, 10)))].sort(
+    (a, b) => b.localeCompare(a)
+  );
+
+  const today = new Date();
+  const todayStr = format(today, "yyyy/MM/dd");
+
+  // If today has no record, start counting from yesterday
+  let checkDate = uniqueDates.includes(todayStr) ? today : subDays(today, 1);
+  let streak = 0;
+
+  for (const dateStr of uniqueDates) {
+    const checkStr = format(checkDate, "yyyy/MM/dd");
+    if (dateStr === checkStr) {
+      streak++;
+      checkDate = subDays(checkDate, 1);
+    } else if (dateStr < checkStr) {
+      // Gap in consecutive days — stop counting
+      break;
+    }
+  }
+
+  return streak;
+}
+
+export function useStreak(posts: PostData[] | undefined): number {
+  return useMemo(() => calculateStreak(posts), [posts]);
+}


### PR DESCRIPTION
## 概要

ホームページ（学習記録フォーム）に、学習モチベーションを高める情報を追加した。

## 対応 Issue

Closes #111

## 変更内容

- `StreakBadge` Atom を新規作成（🔥 N日連続 を表示する MUI Chip コンポーネント）
- `useStreak` フックを新規作成（`posts` 配列から連続学習日数をクライアントサイドで計算）
- `Report` ページに今日の日付を表示（例: 2026年6月19日（金））
- `Report` ページにストリーク（連続学習日数）を表示
- `Report` ページの下部に直近 3 件の学習記録一覧を追加（`/posts` へのリンクつき）

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [ ] テスト通過 (`pnpm test`) ※ロジック変更時
- [ ] lint / build は CI で確認