### PR TITLE
feat: 学習記録一覧に週次合計とフィルタータブを追加する

### DIFF
--- a/src/components/Atoms/Card/index.tsx
+++ b/src/components/Atoms/Card/index.tsx
@@ -24,7 +24,7 @@ const variantStyles: Record<CardVariant, object> = {
   bordered: {
     borderRadius: "var(--radius-card)",
     boxShadow: "none",
-    border: "1px solid var(--mui-palette-divider)",
+    border: "1.5px solid #E2E4F0",
   },
 };
 

--- a/src/components/Molecules/FilterTabs/index.tsx
+++ b/src/components/Molecules/FilterTabs/index.tsx
@@ -27,20 +27,16 @@ export function FilterTabs({ value, onChange }: Props) {
             px: "14px",
             py: "6px",
             borderRadius: "20px",
-            border:
-              value === option.value ? "none" : "1.5px solid #E2E4F0",
-            backgroundColor:
-              value === option.value ? "#4361EE" : "transparent",
-            color:
-              value === option.value ? "#FFFFFF" : "text.secondary",
+            border: value === option.value ? "none" : "1.5px solid #E2E4F0",
+            backgroundColor: value === option.value ? "#4361EE" : "transparent",
+            color: value === option.value ? "#FFFFFF" : "text.secondary",
             fontSize: "12px",
             fontWeight: 600,
             cursor: "pointer",
             lineHeight: 1.5,
             transition: "all 0.15s ease",
             "&:hover": {
-              backgroundColor:
-                value === option.value ? "#3A55D9" : "#F0F3FF",
+              backgroundColor: value === option.value ? "#3A55D9" : "#F0F3FF",
             },
           }}
         >

--- a/src/components/Molecules/FilterTabs/index.tsx
+++ b/src/components/Molecules/FilterTabs/index.tsx
@@ -1,0 +1,52 @@
+import Box from "@mui/material/Box";
+import React from "react";
+
+export type FilterType = "all" | "thisWeek" | "thisMonth";
+
+const FILTER_OPTIONS: { value: FilterType; label: string }[] = [
+  { value: "all", label: "全て" },
+  { value: "thisWeek", label: "今週" },
+  { value: "thisMonth", label: "今月" },
+];
+
+type Props = {
+  value: FilterType;
+  // eslint-disable-next-line no-unused-vars
+  onChange: (value: FilterType) => void;
+};
+
+export function FilterTabs({ value, onChange }: Props) {
+  return (
+    <Box sx={{ display: "flex", gap: "6px" }}>
+      {FILTER_OPTIONS.map((option) => (
+        <Box
+          key={option.value}
+          component="button"
+          onClick={() => onChange(option.value)}
+          sx={{
+            px: "14px",
+            py: "6px",
+            borderRadius: "20px",
+            border:
+              value === option.value ? "none" : "1.5px solid #E2E4F0",
+            backgroundColor:
+              value === option.value ? "#4361EE" : "transparent",
+            color:
+              value === option.value ? "#FFFFFF" : "text.secondary",
+            fontSize: "12px",
+            fontWeight: 600,
+            cursor: "pointer",
+            lineHeight: 1.5,
+            transition: "all 0.15s ease",
+            "&:hover": {
+              backgroundColor:
+                value === option.value ? "#3A55D9" : "#F0F3FF",
+            },
+          }}
+        >
+          {option.label}
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/src/components/Pages/Posts/index.tsx
+++ b/src/components/Pages/Posts/index.tsx
@@ -2,9 +2,9 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { FilterTabs } from "@/components/Molecules/FilterTabs";
 import { LoadingWrapper } from "@/components/Atoms/LoadingWrapper";
 import { Snackbar } from "@/components/Atoms/Snackbar";
+import { FilterTabs } from "@/components/Molecules/FilterTabs";
 import { PostList } from "@/components/Organisms/PostList";
 import { SingleColumn } from "@/components/Templates/SingleColumn";
 import { usePosts } from "./usePosts";

--- a/src/components/Pages/Posts/index.tsx
+++ b/src/components/Pages/Posts/index.tsx
@@ -1,16 +1,22 @@
 "use client";
-import { Typography } from "@mui/material";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import React from "react";
+import { FilterTabs } from "@/components/Molecules/FilterTabs";
 import { LoadingWrapper } from "@/components/Atoms/LoadingWrapper";
 import { Snackbar } from "@/components/Atoms/Snackbar";
 import { PostList } from "@/components/Organisms/PostList";
 import { SingleColumn } from "@/components/Templates/SingleColumn";
-import { usePostData } from "@/libs/hooks/usePostData";
 import { usePosts } from "./usePosts";
 
 export function Posts() {
-  const { posts, isLoading, error } = usePostData();
   const {
+    posts,
+    isLoading,
+    error,
+    weeklyTotal,
+    activeFilter,
+    setActiveFilter,
     isDeleteModalOpen,
     handleOpen,
     onClose,
@@ -20,7 +26,47 @@ export function Posts() {
   } = usePosts();
 
   return (
-    <SingleColumn title={"学習記録一覧"}>
+    <SingleColumn>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 2,
+        }}
+      >
+        <Typography
+          component="h1"
+          sx={{ fontSize: "20px", fontWeight: 700, color: "text.primary" }}
+        >
+          記録
+        </Typography>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: "6px",
+            backgroundColor: "#EEF1FF",
+            borderRadius: "10px",
+            px: "12px",
+            py: "5px",
+          }}
+        >
+          <Typography
+            sx={{ fontSize: "11px", fontWeight: 600, color: "#4361EE" }}
+          >
+            今週
+          </Typography>
+          <Typography
+            sx={{ fontSize: "13px", fontWeight: 700, color: "#4361EE" }}
+          >
+            {weeklyTotal}
+          </Typography>
+        </Box>
+      </Box>
+      <Box sx={{ mb: 2 }}>
+        <FilterTabs value={activeFilter} onChange={setActiveFilter} />
+      </Box>
       <LoadingWrapper isLoading={isLoading} error={error}>
         {posts && posts.length > 0 ? (
           <PostList
@@ -31,7 +77,11 @@ export function Posts() {
             handleDelete={handleDelete}
           />
         ) : (
-          <Typography>まだ投稿データがありません。</Typography>
+          <Typography color="text.secondary">
+            {activeFilter === "all"
+              ? "まだ投稿データがありません。"
+              : "この期間の記録はありません。"}
+          </Typography>
         )}
         <Snackbar
           open={isDeleteSuccess}

--- a/src/components/Pages/Posts/usePosts.ts
+++ b/src/components/Pages/Posts/usePosts.ts
@@ -1,12 +1,39 @@
+import { startOfMonth, startOfWeek } from "date-fns";
 import { SnackbarCloseReason } from "@mui/material";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { FilterType } from "@/components/Molecules/FilterTabs";
 import { usePostData } from "@/libs/hooks/usePostData";
+import { useWeeklyTotal } from "@/libs/hooks/useWeeklyTotal";
+import { PostData } from "@/libs/types";
+
+function filterByDate(posts: PostData[], filter: FilterType): PostData[] {
+  if (filter === "all") return posts;
+
+  const cutoff =
+    filter === "thisWeek"
+      ? startOfWeek(new Date(), { weekStartsOn: 1 })
+      : startOfMonth(new Date());
+
+  return posts.filter((post) => {
+    const postDate = new Date(post.date.slice(0, 10).replace(/\//g, "-"));
+    return postDate >= cutoff;
+  });
+}
 
 export function usePosts() {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
   const [deletePostId, setDeletePostId] = useState<string | null>(null);
-  const { deletePost } = usePostData();
   const [isDeleteSuccess, setIsDeleteSuccess] = useState<boolean>(false);
+  const [activeFilter, setActiveFilter] = useState<FilterType>("all");
+
+  const { posts, rawPosts, isLoading, error, deletePost } = usePostData();
+
+  const weeklyTotal = useWeeklyTotal(rawPosts);
+
+  const filteredPosts = useMemo(
+    () => filterByDate(posts ?? [], activeFilter),
+    [posts, activeFilter]
+  );
 
   const handleOpen = (id: string) => {
     setIsDeleteModalOpen(true);
@@ -34,7 +61,14 @@ export function usePosts() {
     }
     onClose();
   };
+
   return {
+    posts: filteredPosts,
+    isLoading,
+    error,
+    weeklyTotal,
+    activeFilter,
+    setActiveFilter,
     isDeleteModalOpen,
     handleOpen,
     onClose,

--- a/src/components/Pages/Posts/usePosts.ts
+++ b/src/components/Pages/Posts/usePosts.ts
@@ -1,5 +1,5 @@
-import { startOfMonth, startOfWeek } from "date-fns";
 import { SnackbarCloseReason } from "@mui/material";
+import { startOfMonth, startOfWeek } from "date-fns";
 import { useMemo, useState } from "react";
 import { FilterType } from "@/components/Molecules/FilterTabs";
 import { usePostData } from "@/libs/hooks/usePostData";

--- a/src/components/Templates/SingleColumn/index.tsx
+++ b/src/components/Templates/SingleColumn/index.tsx
@@ -4,14 +4,14 @@ import { Heading } from "@/components/Atoms/Heading";
 import styles from "./index.module.scss";
 
 type Props = {
-  title: string;
+  title?: string;
   children: React.ReactNode;
 };
 
 export function SingleColumn({ title, children }: Props) {
   return (
     <Container maxWidth="sm" className={styles.container}>
-      <Heading text={title} />
+      {title && <Heading text={title} />}
       <Box
         sx={{
           mt: 2,

--- a/src/libs/hooks/usePostData.ts
+++ b/src/libs/hooks/usePostData.ts
@@ -122,6 +122,7 @@ export const usePostData = () => {
 
   return {
     posts,
+    rawPosts: data,
     postData,
     isLoading,
     error,

--- a/src/libs/hooks/useWeeklyTotal.ts
+++ b/src/libs/hooks/useWeeklyTotal.ts
@@ -1,0 +1,27 @@
+import { startOfWeek } from "date-fns";
+import { useMemo } from "react";
+import { PostData } from "../types";
+
+export function useWeeklyTotal(rawPosts: PostData[] | undefined): string {
+  return useMemo(() => {
+    if (!rawPosts || rawPosts.length === 0) return "0分";
+
+    const weekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
+
+    const totalMinutes = rawPosts
+      .filter((post) => {
+        const postDate = new Date(
+          post.date.slice(0, 10).replace(/\//g, "-")
+        );
+        return postDate >= weekStart;
+      })
+      .reduce((sum, post) => sum + Number(post.time), 0);
+
+    const hour = Math.floor(totalMinutes / 60);
+    const minute = totalMinutes % 60;
+    if (hour > 0) {
+      return minute > 0 ? `${hour}時間${minute}分` : `${hour}時間`;
+    }
+    return `${minute}分`;
+  }, [rawPosts]);
+}

--- a/src/libs/hooks/useWeeklyTotal.ts
+++ b/src/libs/hooks/useWeeklyTotal.ts
@@ -10,9 +10,7 @@ export function useWeeklyTotal(rawPosts: PostData[] | undefined): string {
 
     const totalMinutes = rawPosts
       .filter((post) => {
-        const postDate = new Date(
-          post.date.slice(0, 10).replace(/\//g, "-")
-        );
+        const postDate = new Date(post.date.slice(0, 10).replace(/\//g, "-"));
         return postDate >= weekStart;
       })
       .reduce((sum, post) => sum + Number(post.time), 0);


### PR DESCRIPTION
## 概要

Issue #112 の対応。学習記録一覧（`/posts`）に週次合計表示とフィルタータブ（全て/今週/今月）を追加する。

## 対応 Issue

Closes #112

## 変更内容

### 新規

- `src/libs/hooks/useWeeklyTotal.ts` — 月〜日曜の合計学習時間を計算するフック
- `src/components/Molecules/FilterTabs/index.tsx` — ピル型フィルタータブ（全て/今週/今月）

### 修正

- `src/libs/hooks/usePostData.ts` — `rawPosts`（time が数値のまま）を return に追加
- `src/components/Pages/Posts/usePosts.ts` — フィルター状態・週次合計・usePostData の呼び出しを集約
- `src/components/Pages/Posts/index.tsx` — ヘッダーをタイトル左＋週次合計バッジ右のレイアウトに変更、FilterTabs を統合
- `src/components/Templates/SingleColumn/index.tsx` — `title` prop をオプション化
- `src/components/Atoms/Card/index.tsx` — bordered バリアントのボーダーを `1.5px solid #E2E4F0` に更新

### 実装メモ

- フィルタータブは Issue 本文の「すべて/教材別」ではなく、デザイン仕様（Screen Layout Handoff）の「全て/今週/今月」で実装
- フィルター状態はローカル state で管理（URL クエリパラメータ不要と判断）
- 週次合計は `rawPosts`（Firestore から取得した time が数値の状態）を使用し、変換済み string データの再パースを回避

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [ ] テスト通過 (`pnpm test`) ※ロジック変更時
- [ ] lint / build は CI で確認