### PR TITLE
feat: 学習統計ページに集計カードと教材別グラフを追加する

### DIFF
--- a/e2e/study-log.spec.ts
+++ b/e2e/study-log.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+import { clearFirestore, seedPost, seedTextbook } from "./helpers/firestore";
+
+test.beforeEach(async () => {
+  await clearFirestore();
+});
+
+test("投稿データがない場合、学習記録がありませんと表示される", async ({
+  page,
+}) => {
+  await page.goto("/study-log");
+
+  await expect(page.getByText("学習記録がありません")).toBeVisible();
+});
+
+test("投稿データがある場合、集計カードと教材別グラフが表示される", async ({
+  page,
+}) => {
+  const textbookId = await seedTextbook("TypeScript");
+  await seedPost({
+    textbookId,
+    textbookName: "TypeScript",
+    timeMinutes: 90,
+    content: "型定義を学んだ",
+  });
+
+  await page.goto("/study-log");
+
+  await expect(page.getByText("今日")).toBeVisible();
+  await expect(page.getByText("今週")).toBeVisible();
+  await expect(page.getByText("累計")).toBeVisible();
+  await expect(page.getByText("TypeScript")).toBeVisible();
+});
+
+test("ナビゲーションから学習統計ページに遷移できる", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("link", { name: "学習統計" }).click();
+
+  await expect(page).toHaveURL("/study-log");
+  await expect(page.getByText("教材別の学習時間")).toBeVisible();
+});

--- a/src/components/Molecules/StatCard/index.module.scss
+++ b/src/components/Molecules/StatCard/index.module.scss
@@ -1,0 +1,5 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}

--- a/src/components/Molecules/StatCard/index.module.scss
+++ b/src/components/Molecules/StatCard/index.module.scss
@@ -1,7 +1,7 @@
 .container {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  text-align: center;
-  gap: 4px;
+  justify-content: space-between;
+  gap: 8px;
 }

--- a/src/components/Molecules/StatCard/index.module.scss
+++ b/src/components/Molecules/StatCard/index.module.scss
@@ -1,7 +1,6 @@
 .container {
   display: flex;
-  flex-direction: row;
-  align-items: center;
+  flex-direction: column;
   justify-content: space-between;
-  gap: 8px;
+  min-height: 52px;
 }

--- a/src/components/Molecules/StatCard/index.module.scss
+++ b/src/components/Molecules/StatCard/index.module.scss
@@ -1,5 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  text-align: center;
   gap: 4px;
 }

--- a/src/components/Molecules/StatCard/index.tsx
+++ b/src/components/Molecules/StatCard/index.tsx
@@ -1,29 +1,52 @@
+import MUICard from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { Card } from "@/components/Atoms/Card";
 import styles from "./index.module.scss";
 
 type Props = {
   label: string;
   value: string;
+  variant?: "default" | "primary";
 };
 
-export function StatCard({ label, value }: Props) {
+export function StatCard({ label, value, variant = "default" }: Props) {
+  const isPrimary = variant === "primary";
   return (
-    <Card variant="soft-shadow">
-      <div className={styles.container}>
-        <Typography variant="caption" color="text.secondary">
-          {label}
-        </Typography>
-        <Typography
-          variant="h6"
-          component="p"
-          color="text.primary"
-          sx={{ fontWeight: 700 }}
-        >
-          {value}
-        </Typography>
-      </div>
-    </Card>
+    <MUICard
+      sx={{
+        borderRadius: "var(--radius-card)",
+        boxShadow: "var(--shadow-card-soft)",
+        border: "none",
+        background: isPrimary
+          ? "linear-gradient(135deg, #3A0CA3 0%, #4361EE 100%)"
+          : "white",
+      }}
+    >
+      <CardContent>
+        <div className={styles.container}>
+          <Typography
+            variant="h6"
+            component="p"
+            sx={{
+              fontWeight: 700,
+              lineHeight: 1.1,
+              color: isPrimary ? "white" : "primary.main",
+            }}
+          >
+            {value}
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{
+              color: isPrimary ? "rgba(255,255,255,0.75)" : "text.disabled",
+              marginTop: "4px",
+            }}
+          >
+            {label}
+          </Typography>
+        </div>
+      </CardContent>
+    </MUICard>
   );
 }

--- a/src/components/Molecules/StatCard/index.tsx
+++ b/src/components/Molecules/StatCard/index.tsx
@@ -1,0 +1,29 @@
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { Card } from "@/components/Atoms/Card";
+import styles from "./index.module.scss";
+
+type Props = {
+  label: string;
+  value: string;
+};
+
+export function StatCard({ label, value }: Props) {
+  return (
+    <Card variant="soft-shadow">
+      <div className={styles.container}>
+        <Typography variant="caption" color="text.secondary">
+          {label}
+        </Typography>
+        <Typography
+          variant="h6"
+          component="p"
+          color="text.primary"
+          sx={{ fontWeight: 700 }}
+        >
+          {value}
+        </Typography>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/Molecules/StatCard/index.tsx
+++ b/src/components/Molecules/StatCard/index.tsx
@@ -26,21 +26,21 @@ export function StatCard({ label, value, variant = "default" }: Props) {
       <CardContent>
         <div className={styles.container}>
           <Typography
-            variant="h6"
             component="p"
             sx={{
               fontWeight: 700,
-              lineHeight: 1.1,
+              fontSize: "0.9375rem",
+              lineHeight: 1.2,
               color: isPrimary ? "white" : "primary.main",
             }}
           >
             {value}
           </Typography>
           <Typography
-            variant="caption"
+            component="p"
             sx={{
+              fontSize: "0.6875rem",
               color: isPrimary ? "rgba(255,255,255,0.75)" : "text.disabled",
-              marginTop: "4px",
             }}
           >
             {label}

--- a/src/components/Organisms/HorizontalBarChart/index.module.scss
+++ b/src/components/Organisms/HorizontalBarChart/index.module.scss
@@ -1,0 +1,41 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 8px;
+  padding: 0;
+  list-style: none;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: minmax(72px, 110px) 1fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+}
+
+.barTrack {
+  background: #e2e4f0;
+  border-radius: 4px;
+  height: 8px;
+  overflow: hidden;
+}
+
+.bar {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+
+.time {
+  min-width: 56px;
+  text-align: right;
+  white-space: nowrap;
+}

--- a/src/components/Organisms/HorizontalBarChart/index.tsx
+++ b/src/components/Organisms/HorizontalBarChart/index.tsx
@@ -1,6 +1,7 @@
+import MUICard from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { Card } from "@/components/Atoms/Card";
 import { TextbookColorDot } from "@/components/Atoms/TextbookColorDot";
 import { TextbookStat } from "@/libs/types";
 import { formatMinutes } from "@/libs/utils/formatMinutes";
@@ -16,48 +17,64 @@ export function HorizontalBarChart({ stats, isLoading }: Props) {
     stats.length > 0 ? Math.max(...stats.map((s) => s.totalMinutes)) : 0;
 
   return (
-    <Card title="教材別の学習時間" variant="soft-shadow">
-      {isLoading ? (
-        <Typography variant="body2" color="text.secondary">
-          読み込み中...
+    <MUICard
+      sx={{
+        borderRadius: "var(--radius-card)",
+        boxShadow: "var(--shadow-card-soft)",
+        border: "none",
+        backgroundColor: "white",
+      }}
+    >
+      <CardContent>
+        <Typography
+          variant="caption"
+          gutterBottom
+          sx={{ display: "block", color: "text.secondary" }}
+        >
+          教材別の学習時間
         </Typography>
-      ) : stats.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          学習記録がありません
-        </Typography>
-      ) : (
-        <ul className={styles.list}>
-          {stats.map((stat) => {
-            const pct =
-              maxMinutes > 0 ? (stat.totalMinutes / maxMinutes) * 100 : 0;
-            const color = stat.textbook.color ?? "#4361EE";
-            const key = stat.textbook.id ?? stat.textbook.name;
-            return (
-              <li key={key} className={styles.row}>
-                <div className={styles.label}>
-                  <TextbookColorDot color={color} />
-                  <Typography variant="body2" noWrap>
-                    {stat.textbook.name}
+        {isLoading ? (
+          <Typography variant="body2" color="text.secondary">
+            読み込み中...
+          </Typography>
+        ) : stats.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            学習記録がありません
+          </Typography>
+        ) : (
+          <ul className={styles.list}>
+            {stats.map((stat) => {
+              const pct =
+                maxMinutes > 0 ? (stat.totalMinutes / maxMinutes) * 100 : 0;
+              const color = stat.textbook.color ?? "#4361EE";
+              const key = stat.textbook.id ?? stat.textbook.name;
+              return (
+                <li key={key} className={styles.row}>
+                  <div className={styles.label}>
+                    <TextbookColorDot color={color} />
+                    <Typography variant="body2" noWrap>
+                      {stat.textbook.name}
+                    </Typography>
+                  </div>
+                  <div className={styles.barTrack}>
+                    <div
+                      className={styles.bar}
+                      style={{ width: `${pct}%`, backgroundColor: color }}
+                    />
+                  </div>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    className={styles.time}
+                  >
+                    {formatMinutes(stat.totalMinutes)}
                   </Typography>
-                </div>
-                <div className={styles.barTrack}>
-                  <div
-                    className={styles.bar}
-                    style={{ width: `${pct}%`, backgroundColor: color }}
-                  />
-                </div>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  className={styles.time}
-                >
-                  {formatMinutes(stat.totalMinutes)}
-                </Typography>
-              </li>
-            );
-          })}
-        </ul>
-      )}
-    </Card>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </MUICard>
   );
 }

--- a/src/components/Organisms/HorizontalBarChart/index.tsx
+++ b/src/components/Organisms/HorizontalBarChart/index.tsx
@@ -1,0 +1,63 @@
+import Typography from "@mui/material/Typography";
+import React from "react";
+import { Card } from "@/components/Atoms/Card";
+import { TextbookColorDot } from "@/components/Atoms/TextbookColorDot";
+import { TextbookStat } from "@/libs/types";
+import { formatMinutes } from "@/libs/utils/formatMinutes";
+import styles from "./index.module.scss";
+
+type Props = {
+  stats: TextbookStat[];
+  isLoading?: boolean;
+};
+
+export function HorizontalBarChart({ stats, isLoading }: Props) {
+  const maxMinutes =
+    stats.length > 0 ? Math.max(...stats.map((s) => s.totalMinutes)) : 0;
+
+  return (
+    <Card title="教材別の学習時間" variant="soft-shadow">
+      {isLoading ? (
+        <Typography variant="body2" color="text.secondary">
+          読み込み中...
+        </Typography>
+      ) : stats.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          学習記録がありません
+        </Typography>
+      ) : (
+        <ul className={styles.list}>
+          {stats.map((stat) => {
+            const pct =
+              maxMinutes > 0 ? (stat.totalMinutes / maxMinutes) * 100 : 0;
+            const color = stat.textbook.color ?? "#4361EE";
+            const key = stat.textbook.id ?? stat.textbook.name;
+            return (
+              <li key={key} className={styles.row}>
+                <div className={styles.label}>
+                  <TextbookColorDot color={color} />
+                  <Typography variant="body2" noWrap>
+                    {stat.textbook.name}
+                  </Typography>
+                </div>
+                <div className={styles.barTrack}>
+                  <div
+                    className={styles.bar}
+                    style={{ width: `${pct}%`, backgroundColor: color }}
+                  />
+                </div>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  className={styles.time}
+                >
+                  {formatMinutes(stat.totalMinutes)}
+                </Typography>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Card>
+  );
+}

--- a/src/components/Pages/Studylog/containers/index.module.scss
+++ b/src/components/Pages/Studylog/containers/index.module.scss
@@ -1,22 +1,5 @@
-.container {
-  padding: var(--spacing-5) var(--spacing-4);
-
-  .logWrapper {
-    display: flex;
-    flex-direction: column;
-
-    .list {
-      display: flex;
-      gap: var(--spacing-5);
-      margin: var(--spacing-1) 0;
-
-      .dataTitle {
-        width: 30%;
-      }
-
-      .dataDefinition {
-        width: 70%;
-      }
-    }
-  }
+.statCards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
 }

--- a/src/components/Pages/Studylog/containers/index.module.scss
+++ b/src/components/Pages/Studylog/containers/index.module.scss
@@ -2,4 +2,5 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 12px;
+  margin-bottom: 20px;
 }

--- a/src/components/Pages/Studylog/containers/index.tsx
+++ b/src/components/Pages/Studylog/containers/index.tsx
@@ -13,7 +13,7 @@ export function StudyLog() {
   return (
     <SingleColumn title="学習統計">
       <div className={styles.statCards}>
-        <StatCard label="今日" value={todayTotal} />
+        <StatCard label="今日" value={todayTotal} variant="primary" />
         <StatCard label="今週" value={weeklyTotal} />
         <StatCard label="累計" value={cumulativeTotal} />
       </div>

--- a/src/components/Pages/Studylog/containers/index.tsx
+++ b/src/components/Pages/Studylog/containers/index.tsx
@@ -1,30 +1,23 @@
 "use client";
 import React from "react";
-import { Card } from "@/components/Atoms/Card";
+import { HorizontalBarChart } from "@/components/Organisms/HorizontalBarChart";
+import { StatCard } from "@/components/Molecules/StatCard";
 import { SingleColumn } from "@/components/Templates/SingleColumn";
 import { useStudyLog } from "./useStudyLog";
+import styles from "./index.module.scss";
 
 export function StudyLog() {
-  const { data } = useStudyLog();
+  const { todayTotal, weeklyTotal, cumulativeTotal, textbookStats, isLoading } =
+    useStudyLog();
 
   return (
-    <SingleColumn title="学習時間">
-      <Card title="教材別の学習時間" variant="soft-shadow">
-        {data ? (
-          // data.map((log) => {
-          //   return (
-          //     /** FIXME: indexを使わないでkeyを入れる */
-          //     <dl key={}>
-          //       <dt>{}</dt>
-          //       <dd>{log.time}分</dd>
-          //     </dl>
-          //   );
-          // })
-          <>dataあり</>
-        ) : (
-          <>学習記録がありません</>
-        )}
-      </Card>
+    <SingleColumn title="学習統計">
+      <div className={styles.statCards}>
+        <StatCard label="今日" value={todayTotal} />
+        <StatCard label="今週" value={weeklyTotal} />
+        <StatCard label="累計" value={cumulativeTotal} />
+      </div>
+      <HorizontalBarChart stats={textbookStats} isLoading={isLoading} />
     </SingleColumn>
   );
 }

--- a/src/components/Pages/Studylog/containers/index.tsx
+++ b/src/components/Pages/Studylog/containers/index.tsx
@@ -1,10 +1,10 @@
 "use client";
 import React from "react";
-import { HorizontalBarChart } from "@/components/Organisms/HorizontalBarChart";
 import { StatCard } from "@/components/Molecules/StatCard";
+import { HorizontalBarChart } from "@/components/Organisms/HorizontalBarChart";
 import { SingleColumn } from "@/components/Templates/SingleColumn";
-import { useStudyLog } from "./useStudyLog";
 import styles from "./index.module.scss";
+import { useStudyLog } from "./useStudyLog";
 
 export function StudyLog() {
   const { todayTotal, weeklyTotal, cumulativeTotal, textbookStats, isLoading } =

--- a/src/components/Pages/Studylog/containers/useStudyLog.ts
+++ b/src/components/Pages/Studylog/containers/useStudyLog.ts
@@ -1,73 +1,24 @@
-import axios from "axios";
-import useSWR from "swr";
-import { PostData, Textbook } from "@/libs/types";
+import { useCumulativeTotal } from "@/libs/hooks/useCumulativeTotal";
+import { usePostData } from "@/libs/hooks/usePostData";
+import { useTodayTotal } from "@/libs/hooks/useTodayTotal";
+import { useTextbookStats } from "@/libs/hooks/useTextbookStats";
+import { useWeeklyTotal } from "@/libs/hooks/useWeeklyTotal";
 
-/** WIP */
-export const useStudyLog = () => {
-  const apiPathToPost = "/api/post";
-  const apiPathToTextbook = "/api/textbook";
+export function useStudyLog() {
+  const { rawPosts, isLoading } = usePostData();
 
-  async function fetchPostData(): Promise<PostData[]> {
-    try {
-      const res = await axios.get(apiPathToPost);
-      return res.data;
-    } catch (error) {
-      throw new Error("データが取得できませんでした。");
-    }
-  }
-
-  async function fetchTextbookData(): Promise<Textbook[]> {
-    try {
-      const res = await axios.get(apiPathToTextbook);
-      return res.data;
-    } catch (error) {
-      throw new Error("データが取得できませんでした。");
-    }
-  }
-
-  /** isLoading, errorハンドリングを記述する */
-  const { data: postData } = useSWR(apiPathToPost, fetchPostData, {
-    onSuccess(data) {
-      return data;
-    },
-    onError(error) {
-      console.log("swr returns error", error);
-    },
-  });
-
-  /** isLoading, errorハンドリングを記述する */
-  const { data: textbooks } = useSWR(apiPathToTextbook, fetchTextbookData, {
-    onSuccess(data) {
-      return data;
-    },
-    onError(error) {
-      console.log("swr returns error", error);
-    },
-  });
-
-  const mappedData = postData?.map((log) => {
-    return { textbook: log.textbook.id, time: Number(log.time) };
-  });
-
-  const logData = textbooks?.map((textbook) => {
-    return { id: textbook.id, name: textbook.name, time: 0 };
-  });
-
-  // textbookのnameでfilterしてmappedData内で同じnameをもつ要素のtimeをまとめる
-  // まとめたものを一つの要素としてもつ配列をtextbooks配列をベースに作り直す。
-  const data = logData?.map((textbook) => {
-    const filteredData = mappedData?.filter((log) => {
-      if (log.textbook === textbook.name) {
-        textbook.time += log.time;
-      }
-    });
-    return filteredData; //戻り値のオブジェクトにidが入るようにしたい
-  });
+  const todayTotal = useTodayTotal(rawPosts);
+  const weeklyTotal = useWeeklyTotal(rawPosts);
+  const cumulativeTotal = useCumulativeTotal(rawPosts);
+  const textbookStats = useTextbookStats(rawPosts);
 
   return {
-    data,
+    todayTotal,
+    weeklyTotal,
+    cumulativeTotal,
+    textbookStats,
+    isLoading,
   };
-};
+}
 
-/** TODO: このコード調べる */
 export type UseStudyLog = ReturnType<typeof useStudyLog>;

--- a/src/components/Pages/Studylog/containers/useStudyLog.ts
+++ b/src/components/Pages/Studylog/containers/useStudyLog.ts
@@ -1,7 +1,7 @@
 import { useCumulativeTotal } from "@/libs/hooks/useCumulativeTotal";
 import { usePostData } from "@/libs/hooks/usePostData";
-import { useTodayTotal } from "@/libs/hooks/useTodayTotal";
 import { useTextbookStats } from "@/libs/hooks/useTextbookStats";
+import { useTodayTotal } from "@/libs/hooks/useTodayTotal";
 import { useWeeklyTotal } from "@/libs/hooks/useWeeklyTotal";
 
 export function useStudyLog() {

--- a/src/components/Templates/Header/useHamburgerMenu.ts
+++ b/src/components/Templates/Header/useHamburgerMenu.ts
@@ -36,11 +36,11 @@ export function useHamburgerMenu() {
       icon: "school",
       href: URL_VALUES.POSTS,
     },
-    // {
-    //   label: "学習時間",
-    //   icon: "time",
-    //   href: URL_VALUES.STUDYLOG,
-    // },
+    {
+      label: "学習統計",
+      icon: "time",
+      href: URL_VALUES.STUDYLOG,
+    },
   ];
 
   return {

--- a/src/libs/hooks/useCumulativeTotal.test.ts
+++ b/src/libs/hooks/useCumulativeTotal.test.ts
@@ -42,8 +42,20 @@ describe("useCumulativeTotal", () => {
 
   it("日付に関わらず全記録を合計するべき", () => {
     const posts: PostData[] = [
-      { id: "1", date: "2025/09/23 10:00", textbook: { id: "t1", name: "A" }, time: 60, content: "" },
-      { id: "2", date: "2025/01/01 10:00", textbook: { id: "t2", name: "B" }, time: 30, content: "" },
+      {
+        id: "1",
+        date: "2025/09/23 10:00",
+        textbook: { id: "t1", name: "A" },
+        time: 60,
+        content: "",
+      },
+      {
+        id: "2",
+        date: "2025/01/01 10:00",
+        textbook: { id: "t2", name: "B" },
+        time: 30,
+        content: "",
+      },
     ];
     const { result } = renderHook(() => useCumulativeTotal(posts));
     expect(result.current).toBe("1時間30分");

--- a/src/libs/hooks/useCumulativeTotal.test.ts
+++ b/src/libs/hooks/useCumulativeTotal.test.ts
@@ -1,0 +1,51 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PostData } from "../types";
+import { useCumulativeTotal } from "./useCumulativeTotal";
+
+const makePost = (time: number): PostData => ({
+  id: "1",
+  date: "2025/09/23 10:00",
+  textbook: { id: "t1", name: "テスト教材" },
+  time,
+  content: "内容",
+});
+
+describe("useCumulativeTotal", () => {
+  it("undefined を渡したとき「0分」を返すべき", () => {
+    const { result } = renderHook(() => useCumulativeTotal(undefined));
+    expect(result.current).toBe("0分");
+  });
+
+  it("空配列を渡したとき「0分」を返すべき", () => {
+    const { result } = renderHook(() => useCumulativeTotal([]));
+    expect(result.current).toBe("0分");
+  });
+
+  it("合計が 60 分未満のとき「N分」形式で返すべき", () => {
+    const posts = [makePost(30), makePost(20)];
+    const { result } = renderHook(() => useCumulativeTotal(posts));
+    expect(result.current).toBe("50分");
+  });
+
+  it("合計がちょうど 60 分のとき「N時間」形式（分なし）で返すべき", () => {
+    const posts = [makePost(30), makePost(30)];
+    const { result } = renderHook(() => useCumulativeTotal(posts));
+    expect(result.current).toBe("1時間");
+  });
+
+  it("合計が 60 分超のとき「N時間M分」形式で返すべき", () => {
+    const posts = [makePost(90), makePost(45)];
+    const { result } = renderHook(() => useCumulativeTotal(posts));
+    expect(result.current).toBe("2時間15分");
+  });
+
+  it("日付に関わらず全記録を合計するべき", () => {
+    const posts: PostData[] = [
+      { id: "1", date: "2025/09/23 10:00", textbook: { id: "t1", name: "A" }, time: 60, content: "" },
+      { id: "2", date: "2025/01/01 10:00", textbook: { id: "t2", name: "B" }, time: 30, content: "" },
+    ];
+    const { result } = renderHook(() => useCumulativeTotal(posts));
+    expect(result.current).toBe("1時間30分");
+  });
+});

--- a/src/libs/hooks/useCumulativeTotal.ts
+++ b/src/libs/hooks/useCumulativeTotal.ts
@@ -1,0 +1,16 @@
+import { useMemo } from "react";
+import { PostData } from "../types";
+import { formatMinutes } from "../utils/formatMinutes";
+
+export function useCumulativeTotal(rawPosts: PostData[] | undefined): string {
+  return useMemo(() => {
+    if (!rawPosts || rawPosts.length === 0) return "0分";
+
+    const totalMinutes = rawPosts.reduce(
+      (sum, post) => sum + Number(post.time),
+      0
+    );
+
+    return formatMinutes(totalMinutes);
+  }, [rawPosts]);
+}

--- a/src/libs/hooks/useTextbookStats.test.ts
+++ b/src/libs/hooks/useTextbookStats.test.ts
@@ -61,8 +61,20 @@ describe("useTextbookStats", () => {
 
   it("教材 ID がない場合は教材名をキーに集計するべき", () => {
     const posts: PostData[] = [
-      { id: "p1", date: "2025/09/23 10:00", textbook: { name: "英語" }, time: 30, content: "" },
-      { id: "p2", date: "2025/09/23 11:00", textbook: { name: "英語" }, time: 20, content: "" },
+      {
+        id: "p1",
+        date: "2025/09/23 10:00",
+        textbook: { name: "英語" },
+        time: 30,
+        content: "",
+      },
+      {
+        id: "p2",
+        date: "2025/09/23 11:00",
+        textbook: { name: "英語" },
+        time: 20,
+        content: "",
+      },
     ];
     const { result } = renderHook(() => useTextbookStats(posts));
     expect(result.current).toHaveLength(1);

--- a/src/libs/hooks/useTextbookStats.test.ts
+++ b/src/libs/hooks/useTextbookStats.test.ts
@@ -1,0 +1,77 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PostData } from "../types";
+import { useTextbookStats } from "./useTextbookStats";
+
+const makePost = (
+  id: string,
+  textbookId: string,
+  textbookName: string,
+  time: number,
+  color = "#4361EE"
+): PostData => ({
+  id,
+  date: "2025/09/23 10:00",
+  textbook: { id: textbookId, name: textbookName, color },
+  time,
+  content: "内容",
+});
+
+describe("useTextbookStats", () => {
+  it("undefined を渡したとき空配列を返すべき", () => {
+    const { result } = renderHook(() => useTextbookStats(undefined));
+    expect(result.current).toEqual([]);
+  });
+
+  it("空配列を渡したとき空配列を返すべき", () => {
+    const { result } = renderHook(() => useTextbookStats([]));
+    expect(result.current).toEqual([]);
+  });
+
+  it("同じ教材 ID の記録をまとめて合計するべき", () => {
+    const posts = [
+      makePost("p1", "t1", "英語", 30),
+      makePost("p2", "t1", "英語", 45),
+    ];
+    const { result } = renderHook(() => useTextbookStats(posts));
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].totalMinutes).toBe(75);
+  });
+
+  it("異なる教材 ID の記録を別々に集計するべき", () => {
+    const posts = [
+      makePost("p1", "t1", "英語", 30),
+      makePost("p2", "t2", "数学", 60),
+    ];
+    const { result } = renderHook(() => useTextbookStats(posts));
+    expect(result.current).toHaveLength(2);
+  });
+
+  it("合計時間の降順でソートされるべき", () => {
+    const posts = [
+      makePost("p1", "t1", "英語", 30),
+      makePost("p2", "t2", "数学", 90),
+      makePost("p3", "t3", "理科", 60),
+    ];
+    const { result } = renderHook(() => useTextbookStats(posts));
+    expect(result.current[0].textbook.name).toBe("数学");
+    expect(result.current[1].textbook.name).toBe("理科");
+    expect(result.current[2].textbook.name).toBe("英語");
+  });
+
+  it("教材 ID がない場合は教材名をキーに集計するべき", () => {
+    const posts: PostData[] = [
+      { id: "p1", date: "2025/09/23 10:00", textbook: { name: "英語" }, time: 30, content: "" },
+      { id: "p2", date: "2025/09/23 11:00", textbook: { name: "英語" }, time: 20, content: "" },
+    ];
+    const { result } = renderHook(() => useTextbookStats(posts));
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].totalMinutes).toBe(50);
+  });
+
+  it("各集計結果に教材の色情報が含まれるべき", () => {
+    const posts = [makePost("p1", "t1", "英語", 30, "#FF5722")];
+    const { result } = renderHook(() => useTextbookStats(posts));
+    expect(result.current[0].textbook.color).toBe("#FF5722");
+  });
+});

--- a/src/libs/hooks/useTextbookStats.ts
+++ b/src/libs/hooks/useTextbookStats.ts
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+import { PostData, TextbookStat } from "../types";
+
+export function useTextbookStats(
+  rawPosts: PostData[] | undefined
+): TextbookStat[] {
+  return useMemo(() => {
+    if (!rawPosts || rawPosts.length === 0) return [];
+
+    const statsMap = new Map<string, TextbookStat>();
+
+    for (const post of rawPosts) {
+      const key = post.textbook.id ?? post.textbook.name;
+      const existing = statsMap.get(key);
+      if (existing) {
+        existing.totalMinutes += Number(post.time);
+      } else {
+        statsMap.set(key, {
+          textbook: post.textbook,
+          totalMinutes: Number(post.time),
+        });
+      }
+    }
+
+    return Array.from(statsMap.values()).sort(
+      (a, b) => b.totalMinutes - a.totalMinutes
+    );
+  }, [rawPosts]);
+}

--- a/src/libs/hooks/useTodayTotal.test.ts
+++ b/src/libs/hooks/useTodayTotal.test.ts
@@ -1,0 +1,68 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PostData } from "../types";
+import { useTodayTotal } from "./useTodayTotal";
+
+// 2025-09-23 (火) 正午に固定（UTC midnight のタイムゾーンズレを回避）
+const FIXED_NOW = new Date("2025-09-23T12:00:00.000Z");
+const TODAY = "2025/09/23 10:00";
+const YESTERDAY = "2025/09/22 10:00";
+
+const makePost = (date: string, time: number): PostData => ({
+  id: "1",
+  date,
+  textbook: { id: "t1", name: "テスト教材" },
+  time,
+  content: "内容",
+});
+
+describe("useTodayTotal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("undefined を渡したとき「0分」を返すべき", () => {
+    const { result } = renderHook(() => useTodayTotal(undefined));
+    expect(result.current).toBe("0分");
+  });
+
+  it("空配列を渡したとき「0分」を返すべき", () => {
+    const { result } = renderHook(() => useTodayTotal([]));
+    expect(result.current).toBe("0分");
+  });
+
+  it("今日の記録が 0 件のとき「0分」を返すべき", () => {
+    const posts = [makePost(YESTERDAY, 30)];
+    const { result } = renderHook(() => useTodayTotal(posts));
+    expect(result.current).toBe("0分");
+  });
+
+  it("今日の合計が 60 分未満のとき「N分」形式で返すべき", () => {
+    const posts = [makePost(TODAY, 45)];
+    const { result } = renderHook(() => useTodayTotal(posts));
+    expect(result.current).toBe("45分");
+  });
+
+  it("今日の合計がちょうど 60 分のとき「N時間」形式（分なし）で返すべき", () => {
+    const posts = [makePost(TODAY, 60)];
+    const { result } = renderHook(() => useTodayTotal(posts));
+    expect(result.current).toBe("1時間");
+  });
+
+  it("今日の合計が 60 分超のとき「N時間M分」形式で返すべき", () => {
+    const posts = [makePost(TODAY, 90), makePost(TODAY, 45)];
+    const { result } = renderHook(() => useTodayTotal(posts));
+    expect(result.current).toBe("2時間15分");
+  });
+
+  it("今日と昨日の記録が混在するとき、今日分のみ合計するべき", () => {
+    const posts = [makePost(TODAY, 60), makePost(YESTERDAY, 120)];
+    const { result } = renderHook(() => useTodayTotal(posts));
+    expect(result.current).toBe("1時間");
+  });
+});

--- a/src/libs/hooks/useTodayTotal.ts
+++ b/src/libs/hooks/useTodayTotal.ts
@@ -1,0 +1,18 @@
+import { format } from "date-fns";
+import { useMemo } from "react";
+import { PostData } from "../types";
+import { formatMinutes } from "../utils/formatMinutes";
+
+export function useTodayTotal(rawPosts: PostData[] | undefined): string {
+  return useMemo(() => {
+    if (!rawPosts || rawPosts.length === 0) return "0分";
+
+    const todayPrefix = format(new Date(), "yyyy/MM/dd");
+
+    const totalMinutes = rawPosts
+      .filter((post) => post.date.startsWith(todayPrefix))
+      .reduce((sum, post) => sum + Number(post.time), 0);
+
+    return formatMinutes(totalMinutes);
+  }, [rawPosts]);
+}

--- a/src/libs/types/index.ts
+++ b/src/libs/types/index.ts
@@ -20,3 +20,9 @@ export type PostData = {
   time: number | string;
   content: string;
 };
+
+/** 教材別集計結果 */
+export type TextbookStat = {
+  textbook: Textbook;
+  totalMinutes: number;
+};

--- a/src/libs/utils/formatMinutes.ts
+++ b/src/libs/utils/formatMinutes.ts
@@ -1,0 +1,8 @@
+export function formatMinutes(totalMinutes: number): string {
+  const hour = Math.floor(totalMinutes / 60);
+  const minute = totalMinutes % 60;
+  if (hour > 0) {
+    return minute > 0 ? `${hour}時間${minute}分` : `${hour}時間`;
+  }
+  return `${minute}分`;
+}


### PR DESCRIPTION
## 概要

`/study-log` ページを「学習の成果が一目でわかるダッシュボード」に刷新する。
集計カード3枚（今日・今週・累計）と教材別横棒グラフを追加し、WIP 状態だった `useStudyLog` を全面的に書き直した。

## 対応 Issue

Closes #114
Closes #90

## 変更内容

### 新規追加

- `src/libs/utils/formatMinutes.ts` — 分数を「N時間M分」形式にフォーマットするユーティリティ
- `src/libs/hooks/useTodayTotal.ts` — 今日の合計学習時間フック
- `src/libs/hooks/useCumulativeTotal.ts` — 累計合計学習時間フック
- `src/libs/hooks/useTextbookStats.ts` — 教材別累計集計フック（合計時間の降順ソート）
- `src/components/Molecules/StatCard/` — ラベル + 時間値を表示する集計カード（soft-shadow バリアント）
- `src/components/Organisms/HorizontalBarChart/` — 教材別横棒グラフ（CSS のみ・外部ライブラリなし）

### 修正

- `src/libs/types/index.ts` — `TextbookStat` 型を追加
- `src/components/Pages/Studylog/containers/useStudyLog.ts` — axios ベースの WIP 実装を廃止。`usePostData` + 集計フック群に統一
- `src/components/Pages/Studylog/containers/index.tsx` — 集計カード3枚 + `HorizontalBarChart` を配置
- `src/components/Pages/Studylog/containers/index.module.scss` — 3カラムグリッドレイアウト

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [x] lint エラーなし (`pnpm lint`)
- [x] テスト通過 (`pnpm test`) — 新規フック3本のテストを含む 58 tests all passed
- [ ] build は CI で確認