### PR TITLE
fix: 古い投稿データで学習統計の教材カラーが青固定になる問題を修正する

### DIFF
--- a/src/components/Pages/Studylog/containers/useStudyLog.ts
+++ b/src/components/Pages/Studylog/containers/useStudyLog.ts
@@ -1,16 +1,29 @@
+import { useMemo } from "react";
 import { useCumulativeTotal } from "@/libs/hooks/useCumulativeTotal";
 import { usePostData } from "@/libs/hooks/usePostData";
+import { useTextbookData } from "@/libs/hooks/useTextbookData";
 import { useTextbookStats } from "@/libs/hooks/useTextbookStats";
 import { useTodayTotal } from "@/libs/hooks/useTodayTotal";
 import { useWeeklyTotal } from "@/libs/hooks/useWeeklyTotal";
 
 export function useStudyLog() {
   const { rawPosts, isLoading } = usePostData();
+  const { textbooks } = useTextbookData();
+
+  const textbookColorMap = useMemo(
+    () =>
+      new Map(
+        textbooks
+          .filter((t) => t.id !== undefined)
+          .map((t) => [t.id as string, t.color])
+      ),
+    [textbooks]
+  );
 
   const todayTotal = useTodayTotal(rawPosts);
   const weeklyTotal = useWeeklyTotal(rawPosts);
   const cumulativeTotal = useCumulativeTotal(rawPosts);
-  const textbookStats = useTextbookStats(rawPosts);
+  const textbookStats = useTextbookStats(rawPosts, textbookColorMap);
 
   return {
     todayTotal,

--- a/src/libs/hooks/useTextbookStats.test.ts
+++ b/src/libs/hooks/useTextbookStats.test.ts
@@ -86,4 +86,57 @@ describe("useTextbookStats", () => {
     const { result } = renderHook(() => useTextbookStats(posts));
     expect(result.current[0].textbook.color).toBe("#FF5722");
   });
+
+  describe("textbookColorMap による色補完", () => {
+    it("post に color がなく textbookColorMap に一致する ID があるとき、マップの色を返すべき", () => {
+      const posts: PostData[] = [
+        {
+          id: "p1",
+          date: "2025/09/23 10:00",
+          textbook: { id: "t1", name: "英語" },
+          time: 30,
+          content: "",
+        },
+      ];
+      const colorMap = new Map([["t1", "#10B981"]]);
+      const { result } = renderHook(() => useTextbookStats(posts, colorMap));
+      expect(result.current[0].textbook.color).toBe("#10B981");
+    });
+
+    it("post に color があり textbookColorMap にも色があるとき、post の color を優先すべき", () => {
+      const posts = [makePost("p1", "t1", "英語", 30, "#FF5722")];
+      const colorMap = new Map([["t1", "#10B981"]]);
+      const { result } = renderHook(() => useTextbookStats(posts, colorMap));
+      expect(result.current[0].textbook.color).toBe("#FF5722");
+    });
+
+    it("post に color がなく textbookColorMap に一致する ID がないとき、color が undefined であるべき", () => {
+      const posts: PostData[] = [
+        {
+          id: "p1",
+          date: "2025/09/23 10:00",
+          textbook: { id: "t1", name: "英語" },
+          time: 30,
+          content: "",
+        },
+      ];
+      const colorMap = new Map([["t2", "#10B981"]]);
+      const { result } = renderHook(() => useTextbookStats(posts, colorMap));
+      expect(result.current[0].textbook.color).toBeUndefined();
+    });
+
+    it("post に color がなく textbookColorMap を渡さないとき、color が undefined であるべき", () => {
+      const posts: PostData[] = [
+        {
+          id: "p1",
+          date: "2025/09/23 10:00",
+          textbook: { id: "t1", name: "英語" },
+          time: 30,
+          content: "",
+        },
+      ];
+      const { result } = renderHook(() => useTextbookStats(posts));
+      expect(result.current[0].textbook.color).toBeUndefined();
+    });
+  });
 });

--- a/src/libs/hooks/useTextbookStats.ts
+++ b/src/libs/hooks/useTextbookStats.ts
@@ -2,7 +2,8 @@ import { useMemo } from "react";
 import { PostData, TextbookStat } from "../types";
 
 export function useTextbookStats(
-  rawPosts: PostData[] | undefined
+  rawPosts: PostData[] | undefined,
+  textbookColorMap?: Map<string, string | undefined>
 ): TextbookStat[] {
   return useMemo(() => {
     if (!rawPosts || rawPosts.length === 0) return [];
@@ -11,12 +12,17 @@ export function useTextbookStats(
 
     for (const post of rawPosts) {
       const key = post.textbook.id ?? post.textbook.name;
+      const resolvedColor =
+        post.textbook.color ??
+        (post.textbook.id
+          ? textbookColorMap?.get(post.textbook.id)
+          : undefined);
       const existing = statsMap.get(key);
       if (existing) {
         existing.totalMinutes += Number(post.time);
       } else {
         statsMap.set(key, {
-          textbook: post.textbook,
+          textbook: { ...post.textbook, color: resolvedColor },
           totalMinutes: Number(post.time),
         });
       }
@@ -25,5 +31,5 @@ export function useTextbookStats(
     return Array.from(statsMap.values()).sort(
       (a, b) => b.totalMinutes - a.totalMinutes
     );
-  }, [rawPosts]);
+  }, [rawPosts, textbookColorMap]);
 }


### PR DESCRIPTION
## 概要

color フィールド導入前に保存された投稿データは `posts` コレクションの埋め込み textbook オブジェクトに `color` が存在しないため、学習統計画面で全教材が青（フォールバック色）で表示されていた。

読み取り時に `textbooks` コレクションのカラー情報で補完することで、データ変更なしに修正する。

## 対応 Issue

Closes #122

## 変更内容

- `useTextbookStats` に `textbookColorMap?: Map<string, string | undefined>` 引数を追加
  - `post.textbook.color` が未定義のとき、textbook ID でマップを引いて色を補完する
  - 優先順位: `post.textbook.color` > `textbookColorMap.get(id)` > `undefined`
- `useStudyLog` で `useTextbookData` を呼び出してカラーマップを生成し `useTextbookStats` に渡す
- `useTextbookStats.test.ts` にカラーマップ補完ケースのテストを 4 件追加

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [x] lint エラーなし (`pnpm lint`)
- [x] テスト通過 (`pnpm test`) — 11 件全通過
- [ ] build は CI で確認