### PR TITLE
fix: 学習統計の教材カラーを登録済み教材画面と一致させる（再修正）

### DIFF
--- a/src/components/Pages/Studylog/containers/useStudyLog.ts
+++ b/src/components/Pages/Studylog/containers/useStudyLog.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { TEXTBOOK_COLOR_PALETTE } from "@/libs/constants/textbookColors";
 import { useCumulativeTotal } from "@/libs/hooks/useCumulativeTotal";
 import { usePostData } from "@/libs/hooks/usePostData";
 import { useTextbookData } from "@/libs/hooks/useTextbookData";
@@ -10,12 +11,16 @@ export function useStudyLog() {
   const { rawPosts, isLoading } = usePostData();
   const { textbooks } = useTextbookData();
 
+  // RegisteredBook と同じフォールバックロジック: color 未保存の古い教材はインデックス順でパレットから割り当て
   const textbookColorMap = useMemo(
     () =>
       new Map(
         textbooks
           .filter((t) => t.id !== undefined)
-          .map((t) => [t.id as string, t.color])
+          .map((t, index) => [
+            t.id as string,
+            t.color ?? TEXTBOOK_COLOR_PALETTE[index % TEXTBOOK_COLOR_PALETTE.length],
+          ])
       ),
     [textbooks]
   );

--- a/src/components/Pages/Studylog/containers/useStudyLog.ts
+++ b/src/components/Pages/Studylog/containers/useStudyLog.ts
@@ -19,7 +19,8 @@ export function useStudyLog() {
           .filter((t) => t.id !== undefined)
           .map((t, index) => [
             t.id as string,
-            t.color ?? TEXTBOOK_COLOR_PALETTE[index % TEXTBOOK_COLOR_PALETTE.length],
+            t.color ??
+              TEXTBOOK_COLOR_PALETTE[index % TEXTBOOK_COLOR_PALETTE.length],
           ])
       ),
     [textbooks]


### PR DESCRIPTION
## 概要

PR #123 のマージ後もカラーが一致しない問題が残っていたため、根本原因を特定して再修正した。

### 根本原因

`RegisteredBook` コンポーネントは `textbook.color` が未保存の古い教材に対して
`TEXTBOOK_COLOR_PALETTE[index]`（リスト上の順番）でフォールバック色を割り当てていた。
PR #123 の修正では `textbookColorMap` に `undefined` がセットされ、
統計画面では引き続き青いフォールバック（`#4361EE`）が表示されていた。

### 対応

`useStudyLog` のカラーマップ生成で、`color` が未保存の教材に対して
`RegisteredBook` と同じインデックスベースのフォールバックを適用する。

```ts
// Before
.map((t) => [t.id as string, t.color])

// After
.map((t, index) => [
  t.id as string,
  t.color ?? TEXTBOOK_COLOR_PALETTE[index % TEXTBOOK_COLOR_PALETTE.length],
])
```

## 対応 Issue

Closes #122

## 変更内容

- `useStudyLog`: カラーマップ生成に `TEXTBOOK_COLOR_PALETTE[index]` フォールバックを追加

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [x] lint エラーなし (`pnpm lint`)
- [x] テスト通過 (`pnpm test`) — 11 件全通過
- [ ] build は CI で確認