### PR TITLE
feat: 投稿カードと最近の記録に教材カラードットを追加する

### DIFF
--- a/src/components/Molecules/Post/index.test.tsx
+++ b/src/components/Molecules/Post/index.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { PostData } from "@/libs/types";
+import { Post } from "./index";
+
+const makePostData = (color?: string): PostData => ({
+  id: "post-1",
+  date: "2025/09/23 10:00",
+  textbook: { id: "t1", name: "TypeScript", color },
+  time: "1時間30分",
+  content: "型ガードとユニオン型を学習した",
+});
+
+describe("Post", () => {
+  it("教材名が表示されるべき", () => {
+    render(<Post data={makePostData("#06B6D4")} handleOpen={vi.fn()} />);
+    expect(screen.getByText("TypeScript")).toBeInTheDocument();
+  });
+
+  it("学習内容が表示されるべき", () => {
+    render(<Post data={makePostData("#06B6D4")} handleOpen={vi.fn()} />);
+    expect(screen.getByText("型ガードとユニオン型を学習した")).toBeInTheDocument();
+  });
+
+  it("削除ボタンをクリックすると handleOpen が投稿 ID で呼ばれるべき", () => {
+    const handleOpen = vi.fn();
+    render(<Post data={makePostData()} handleOpen={handleOpen} />);
+    fireEvent.click(screen.getByRole("button", { name: /削除/ }));
+    expect(handleOpen).toHaveBeenCalledWith("post-1");
+  });
+
+  it("textbook.color が設定されているときカラードットが表示されるべき", () => {
+    const { container: withColor } = render(
+      <Post data={makePostData("#06B6D4")} handleOpen={vi.fn()} />
+    );
+    const { container: withoutColor } = render(
+      <Post data={makePostData()} handleOpen={vi.fn()} />
+    );
+    // TextbookColorDot は span として描画されるため、color あり時の方が span 数が多い
+    const spanCountWithColor = withColor.querySelectorAll("span").length;
+    const spanCountWithoutColor = withoutColor.querySelectorAll("span").length;
+    expect(spanCountWithColor).toBeGreaterThan(spanCountWithoutColor);
+  });
+
+  it("textbook.color が未設定のときカラードットなしで正常にレンダリングされるべき", () => {
+    render(<Post data={makePostData()} handleOpen={vi.fn()} />);
+    expect(screen.getByText("TypeScript")).toBeInTheDocument();
+  });
+});

--- a/src/components/Molecules/Post/index.test.tsx
+++ b/src/components/Molecules/Post/index.test.tsx
@@ -20,7 +20,9 @@ describe("Post", () => {
 
   it("学習内容が表示されるべき", () => {
     render(<Post data={makePostData("#06B6D4")} handleOpen={vi.fn()} />);
-    expect(screen.getByText("型ガードとユニオン型を学習した")).toBeInTheDocument();
+    expect(
+      screen.getByText("型ガードとユニオン型を学習した")
+    ).toBeInTheDocument();
   });
 
   it("削除ボタンをクリックすると handleOpen が投稿 ID で呼ばれるべき", () => {

--- a/src/components/Molecules/Post/index.tsx
+++ b/src/components/Molecules/Post/index.tsx
@@ -22,7 +22,9 @@ export function Post({ data, handleOpen }: Props) {
     <Card title={date} variant="bordered">
       <div className={styles.wrapper}>
         <Box sx={{ display: "flex", alignItems: "center", gap: "6px" }}>
-          {textbook.color && <TextbookColorDot color={textbook.color} size={8} />}
+          {textbook.color && (
+            <TextbookColorDot color={textbook.color} size={8} />
+          )}
           <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
             {textbook.name}
           </Typography>

--- a/src/components/Molecules/Post/index.tsx
+++ b/src/components/Molecules/Post/index.tsx
@@ -1,9 +1,11 @@
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { Card } from "@/components/Atoms/Card";
 import { Icon } from "@/components/Atoms/Icon";
+import { TextbookColorDot } from "@/components/Atoms/TextbookColorDot";
 import { TimeBadge } from "@/components/Atoms/TimeBadge";
 import { PostData } from "@/libs/types";
 import styles from "./index.module.scss";
@@ -19,9 +21,12 @@ export function Post({ data, handleOpen }: Props) {
   return (
     <Card title={date} variant="bordered">
       <div className={styles.wrapper}>
-        <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
-          {textbook.name}
-        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: "6px" }}>
+          {textbook.color && <TextbookColorDot color={textbook.color} size={8} />}
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            {textbook.name}
+          </Typography>
+        </Box>
         <TimeBadge time={String(time)} />
       </div>
       <Divider sx={{ my: 1 }} />

--- a/src/components/Pages/Posts/usePosts.ts
+++ b/src/components/Pages/Posts/usePosts.ts
@@ -2,7 +2,9 @@ import { SnackbarCloseReason } from "@mui/material";
 import { startOfMonth, startOfWeek } from "date-fns";
 import { useMemo, useState } from "react";
 import { FilterType } from "@/components/Molecules/FilterTabs";
+import { TEXTBOOK_COLOR_PALETTE } from "@/libs/constants/textbookColors";
 import { usePostData } from "@/libs/hooks/usePostData";
+import { useTextbookData } from "@/libs/hooks/useTextbookData";
 import { useWeeklyTotal } from "@/libs/hooks/useWeeklyTotal";
 import { PostData } from "@/libs/types";
 
@@ -27,13 +29,38 @@ export function usePosts() {
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
 
   const { posts, rawPosts, isLoading, error, deletePost } = usePostData();
+  const { textbooks } = useTextbookData();
 
   const weeklyTotal = useWeeklyTotal(rawPosts);
 
-  const filteredPosts = useMemo(
-    () => filterByDate(posts ?? [], activeFilter),
-    [posts, activeFilter]
+  const textbookColorMap = useMemo(
+    () =>
+      new Map(
+        textbooks
+          .filter((t) => t.id !== undefined)
+          .map((t, index) => [
+            t.id as string,
+            t.color ?? TEXTBOOK_COLOR_PALETTE[index % TEXTBOOK_COLOR_PALETTE.length],
+          ])
+      ),
+    [textbooks]
   );
+
+  const filteredPosts = useMemo(() => {
+    const filtered = filterByDate(posts ?? [], activeFilter);
+    return filtered.map((post) => ({
+      ...post,
+      textbook: {
+        ...post.textbook,
+        color:
+          post.textbook.color ??
+          (post.textbook.id
+            ? textbookColorMap.get(post.textbook.id)
+            : undefined) ??
+          TEXTBOOK_COLOR_PALETTE[0],
+      },
+    }));
+  }, [posts, activeFilter, textbookColorMap]);
 
   const handleOpen = (id: string) => {
     setIsDeleteModalOpen(true);

--- a/src/components/Pages/Posts/usePosts.ts
+++ b/src/components/Pages/Posts/usePosts.ts
@@ -40,7 +40,8 @@ export function usePosts() {
           .filter((t) => t.id !== undefined)
           .map((t, index) => [
             t.id as string,
-            t.color ?? TEXTBOOK_COLOR_PALETTE[index % TEXTBOOK_COLOR_PALETTE.length],
+            t.color ??
+              TEXTBOOK_COLOR_PALETTE[index % TEXTBOOK_COLOR_PALETTE.length],
           ])
       ),
     [textbooks]

--- a/src/components/Pages/Report/index.tsx
+++ b/src/components/Pages/Report/index.tsx
@@ -6,6 +6,7 @@ import NextLink from "next/link";
 import React from "react";
 import { Icon } from "@/components/Atoms/Icon";
 import { StreakBadge } from "@/components/Atoms/StreakBadge";
+import { TextbookColorDot } from "@/components/Atoms/TextbookColorDot";
 import { ReportForm } from "@/components/Organisms/ReportForm";
 import { SingleColumn } from "@/components/Templates/SingleColumn";
 import { useReport } from "./useReport";
@@ -102,18 +103,30 @@ export function Report() {
                   <Icon icon="book" fontSize="small" color="inherit" />
                 </Box>
                 <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography
+                  <Box
                     sx={{
-                      fontSize: "12px",
-                      fontWeight: 600,
-                      color: "text.primary",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "5px",
                       overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
                     }}
                   >
-                    {post.textbook.name}
-                  </Typography>
+                    {post.textbook.color && (
+                      <TextbookColorDot color={post.textbook.color} size={7} />
+                    )}
+                    <Typography
+                      sx={{
+                        fontSize: "12px",
+                        fontWeight: 600,
+                        color: "text.primary",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {post.textbook.name}
+                    </Typography>
+                  </Box>
                   <Typography
                     sx={{ fontSize: "10px", color: "text.disabled", mt: "1px" }}
                   >

--- a/src/components/Pages/Report/index.tsx
+++ b/src/components/Pages/Report/index.tsx
@@ -90,15 +90,16 @@ export function Report() {
                   sx={{
                     width: 28,
                     height: 28,
-                    backgroundColor: "#EEF1FF",
+                    backgroundColor: post.textbook.color ?? "#EEF1FF",
                     borderRadius: "6px",
                     flexShrink: 0,
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
+                    color: "white",
                   }}
                 >
-                  <Icon icon="book" fontSize="small" color="primary" />
+                  <Icon icon="book" fontSize="small" color="inherit" />
                 </Box>
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Typography

--- a/src/components/Pages/Report/useReport.ts
+++ b/src/components/Pages/Report/useReport.ts
@@ -40,7 +40,8 @@ export function useReport() {
           .filter((t) => t.id !== undefined)
           .map((t, index) => [
             t.id as string,
-            t.color ?? TEXTBOOK_COLOR_PALETTE[index % TEXTBOOK_COLOR_PALETTE.length],
+            t.color ??
+              TEXTBOOK_COLOR_PALETTE[index % TEXTBOOK_COLOR_PALETTE.length],
           ])
       ),
     [textbooks]

--- a/src/components/Pages/Report/useReport.ts
+++ b/src/components/Pages/Report/useReport.ts
@@ -2,6 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { format, subDays } from "date-fns";
 import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
+import { TEXTBOOK_COLOR_PALETTE } from "@/libs/constants/textbookColors";
 import { usePostData } from "@/libs/hooks/usePostData";
 import { useStreak } from "@/libs/hooks/useStreak";
 import { useTextbookData } from "@/libs/hooks/useTextbookData";
@@ -32,13 +33,35 @@ export function useReport() {
     return `${now.getFullYear()}年${now.getMonth() + 1}月${now.getDate()}日（${DAYS[now.getDay()]}）`;
   }, []);
 
+  const textbookColorMap = useMemo(
+    () =>
+      new Map(
+        textbooks
+          .filter((t) => t.id !== undefined)
+          .map((t, index) => [
+            t.id as string,
+            t.color ?? TEXTBOOK_COLOR_PALETTE[index % TEXTBOOK_COLOR_PALETTE.length],
+          ])
+      ),
+    [textbooks]
+  );
+
   const recentPosts = useMemo(
     () =>
       posts?.slice(0, 3).map((post) => ({
         ...post,
         relativeDateLabel: getRelativeDateLabel(post.date),
+        textbook: {
+          ...post.textbook,
+          color:
+            post.textbook.color ??
+            (post.textbook.id
+              ? textbookColorMap.get(post.textbook.id)
+              : undefined) ??
+            TEXTBOOK_COLOR_PALETTE[0],
+        },
       })) ?? [],
-    [posts]
+    [posts, textbookColorMap]
   );
 
   const [alertShown, setAlertShown] = useState<boolean>(false);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,13 @@
 /// <reference types="vitest" />
+import path from "path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
## 概要

学習記録一覧（/posts）の投稿カードと、ホーム（/）の最近の記録に教材カラーを表示する。

## 対応 Issue

Closes #125

## 変更内容

- `usePosts.ts`: `useTextbookData` を追加し textbook color map を構築。`filteredPosts` の `textbook.color` を補完する（旧投稿対応）
- `Post` molecule: 教材名横に `TextbookColorDot`（8px）を表示する
- `useReport.ts`: textbook color map を構築し、`recentPosts` の `textbook.color` を補完する
- `Report/index.tsx`: 最近の記録行の book icon 背景色を教材カラーに変更する
- `vitest.config.ts`: `@` エイリアスを追加（`@/` import を使うコンポーネントのテストを可能に）
- `Post/index.test.tsx`: 教材カラードットの表示・非表示テストを追加する

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [x] lint エラーなし (`pnpm lint`)
- [x] テスト通過 (`pnpm test`) — 67 テスト全通過
- [ ] build は CI で確認