### PR TITLE
feat: 認証機能（ログイン機能）を実装する

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,26 +1,21 @@
 {
-  // Example:
-  //
-  // "indexes": [
-  //   {
-  //     "collectionGroup": "widgets",
-  //     "queryScope": "COLLECTION",
-  //     "fields": [
-  //       { "fieldPath": "foo", "arrayConfig": "CONTAINS" },
-  //       { "fieldPath": "bar", "mode": "DESCENDING" }
-  //     ]
-  //   },
-  //
-  //  "fieldOverrides": [
-  //    {
-  //      "collectionGroup": "widgets",
-  //      "fieldPath": "baz",
-  //      "indexes": [
-  //        { "order": "ASCENDING", "queryScope": "COLLECTION" }
-  //      ]
-  //    },
-  //   ]
-  // ]
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "posts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "uid", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "textbooks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "uid", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }


### PR DESCRIPTION
## 概要

Firestore の複合インデックス定義をコードベースに追加した。デプロイ後に `uid` + `createdAt` でフィルタ・ソートするクエリがインデックス不足エラーになっていたため、`firestore.indexes.json` に定義を追加して次回デプロイ時から自動反映されるようにした。

## 対応 Issue

Closes #104

## 変更内容

- `firestore.indexes.json` に `posts` / `textbooks` コレクションの複合インデックス（`uid` ASC + `createdAt` DESC/ASC）を追加

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [x] lint エラーなし (`pnpm lint`)
- [ ] build は CI で確認