### PR TITLE
chore: デザイントークンをデザイン仕様に合わせて更新する

### DIFF
--- a/src/assets/styles/variable.scss
+++ b/src/assets/styles/variable.scss
@@ -32,10 +32,26 @@
   --containerSmall: 360px;
 
   // カラー・背景色はMUIテーマ(cssVariables)が --mui-palette-* として管理する
+  // 以下はMUIが自動生成しないサブカラー・テキスト・ボーダートークン
+  --color-primary-50: #eef1ff;
+  --color-primary-200: #c5ceff;
+  --color-primary-400: #748ffc;
+  --color-primary-900: #3a0ca3;
+  --color-secondary: #f9a825;
+  --color-accent: #0cc8e8;
+  --color-success: #22c55e;
+  --color-border: #e2e4f0;
+  --color-text-1: #1a1d3b;
+  --color-text-2: #5c6285;
+  --color-text-3: #9194af;
 
   //shadow (MUI管理外のカスタムトークン)
-  --shadow-card-soft: 0 2px 12px rgba(67, 97, 238, 0.10);
+  --shadow-soft: 0 2px 12px rgba(67, 97, 238, 0.1);
+  --shadow-card-soft: 0 2px 12px rgba(67, 97, 238, 0.1);
   --shadow-card-hover: 0 8px 32px rgba(67, 97, 238, 0.12);
+
+  //border (MUI管理外のカスタムトークン)
+  --border-list-card: 1.5px solid #e2e4f0;
 
   //border-radius (MUI管理外のカスタムトークン)
   --radius-card: 12px;


### PR DESCRIPTION
## 概要

デザイン仕様（Screen Layout Handoff）との乖離を解消するため、`variable.scss` にMUIが自動生成しない CSS カスタムプロパティを追加した。

## 対応 Issue

Closes #127

## 変更内容

- `src/assets/styles/variable.scss` にカラートークンを追加
  - `--color-primary-50 / 200 / 400 / 900`
  - `--color-secondary`, `--color-accent`, `--color-success`
  - `--color-border`, `--color-text-1 / 2 / 3`
- `--shadow-soft` を追加（仕様名エイリアス。既存の `--shadow-card-soft` は互換維持のため存続）
- `--border-list-card: 1.5px solid #E2E4F0` を追加
- 背景色（`#F5F6FC`）と `primary.main`（`#4361EE`）はテーマファイルで既に仕様値に更新済みであることを確認

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [x] lint エラーなし (`pnpm lint`)
- [ ] テスト通過 (`pnpm test`) ※ロジック変更なしのためスキップ
- [ ] build は CI で確認