### PR TITLE
docs: README を現在のプロジェクト状態に更新する

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,82 @@
 
 ## アプリ紹介
 
-![alt text](/public/image.png)
+![Study Tracker](public/image.png)
 
-主な機能
+### 主な機能
 
+- Google アカウントによる認証（ログイン）
 - 学習記録の登録
-- 教材登録・編集・削除
+- 学習統計の確認（今日・今週・累計・教材別集計）
+- 教材の登録・編集・削除
 - 学習記録一覧の表示・削除
+
+---
+
+## 技術スタック
+
+| カテゴリ | 技術 |
+|---|---|
+| フレームワーク | Next.js 16 (App Router) |
+| 言語 | TypeScript (strict mode) |
+| UI ライブラリ | MUI (Material UI) v9 + Emotion |
+| スタイリング | SCSS Modules |
+| 状態管理 | Jotai |
+| データ取得 | SWR + Firestore リアルタイムリスナー |
+| フォーム | React Hook Form + Zod |
+| バックエンド | Firebase / Firestore |
+| 認証 | Firebase Auth (Google OAuth) |
+| ホスティング | Firebase App Hosting |
+| テスト | Vitest + Testing Library / Playwright (E2E) |
+| コンポーネント開発 | Storybook |
+
+---
+
+## ローカル開発
+
+### 前提条件
+
+- Node.js 20+
+- pnpm 9+
+- Firebase CLI
+
+### セットアップ
+
+```bash
+# 依存パッケージのインストール
+pnpm install
+
+# 環境変数の設定（Firebase 設定・App Check デバッグトークンを記入）
+cp .env.local.example .env.local
+
+# Firebase エミュレーター起動（Firestore + Auth、port 8080）
+pnpm mock
+
+# 開発サーバー起動（別ターミナル）
+pnpm dev
+```
+
+開発サーバーは http://localhost:3000 で起動します。  
+`NODE_ENV === "development"` 時にエミュレーターへ自動接続されます。
+
+---
+
+## スクリプト一覧
+
+| コマンド | 説明 |
+|---|---|
+| `pnpm dev` | 開発サーバー起動 (localhost:3000) |
+| `pnpm lint` | ESLint 実行 |
+| `pnpm type-check` | 型チェック (tsc --noEmit) |
+| `pnpm test` | Vitest 単発実行 |
+| `pnpm test:watch` | Vitest ウォッチモード |
+| `pnpm test:e2e:local` | E2E テスト（エミュレーター自動起動） |
+| `pnpm mock` | Firebase エミュレーター起動 |
+| `pnpm storybook` | Storybook 起動 (localhost:6006) |
 
 ---
 
 ## 公開記事
 
 アプリ開発の詳細はこちらの記事で紹介しています：  
- [Zenn: Next.js + TypeScriptで作った学習管理アプリ『study-tracker』を振り返る](https://zenn.dev/nekonoko2323/articles/795d624f3293c7)
+[Zenn: Next.js + TypeScriptで作った学習管理アプリ『study-tracker』を振り返る](https://zenn.dev/nekonoko2323/articles/795d624f3293c7)


### PR DESCRIPTION
## 概要

バージョン1時点で書かれた README を現在のプロジェクト状態に合わせて更新する。

## 対応 Issue

Closes #135

## 変更内容

- 機能一覧に「Google アカウント認証（ログイン）」「学習統計の確認（今日・今週・累計・教材別）」を追加
- 技術スタックセクションを新規追加（Next.js 16, React 19, MUI v9, Firebase Auth, Jotai, SWR, React Hook Form + Zod 等）
- ローカル開発セットアップ手順を新規追加（pnpm, Firebase エミュレーター）
- スクリプト一覧セクションを新規追加
- スクリーンショットの参照パスを `/public/image.png` → `public/image.png` に修正（GitHub での表示対応）

## 確認事項

- [x] 型エラーなし (`pnpm type-check`)
- [x] lint エラーなし (`pnpm lint`)
- [ ] テスト通過 (`pnpm test`) ※ドキュメント変更のみのため不要
- [ ] build は CI で確認